### PR TITLE
ci: remove org-level Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":disableDependencyDashboard"
-  ]
-}


### PR DESCRIPTION
All repos have migrated to Dependabot. The org-level `renovate.json` is no longer needed.

- Removes `.github/renovate.json`