### PR TITLE
feat: declarative GitHub state in deploy/ (Crossplane, consumed by platform)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -30,12 +30,11 @@ jobs:
       contents: read # checkout
       packages: write # push the OCI artifact to GHCR
       id-token: write # keyless cosign signing (Fulcio + Rekor via GitHub OIDC)
-    # Pinned to a commit SHA (zizmor blanket policy requires a hash). This is the
-    # reusable-workflows#319 branch head that introduces publish-manifests.yaml;
-    # re-pin to the release commit SHA once #319 merges and cuts a release
-    # (Renovate then manages this pin, as it does for publish-app.yaml elsewhere).
+    # Pinned to the released commit SHA (zizmor blanket policy requires a hash;
+    # the SHA must be reachable from a tag, or zizmor flags it as an impostor).
+    # Renovate manages this pin, as it does for publish-app.yaml elsewhere.
     # The platform verifier matches `@.+$`, so the ref does not affect cosign
     # verification.
-    uses: devantler-tech/reusable-workflows/.github/workflows/publish-manifests.yaml@44742c4f2093025a3dd2261479ccff9c8c893418 # reusable-workflows#319 (pre-release)
+    uses: devantler-tech/reusable-workflows/.github/workflows/publish-manifests.yaml@f974f62a8cb396130fa084d209ad1fc17e99b9fc # v5.6.1
     with:
       oci-name: devantler-tech/github-config

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,70 @@
+name: 🚀 CD
+
+# Publishes the org's declarative GitHub state (deploy/) as a cosign-signed OCI
+# artifact consumed by the platform cluster's `github-config` tenant. Unlike an
+# application repo, there is NO container image here — only manifests — so this
+# pushes a manifests-only artifact (no docker build). The OCI path is
+# `github-config` rather than the repo name, because `.github` is an invalid OCI
+# path component (leading dot).
+#
+# NOTE: a manifests-only publish is a generic pattern; a follow-up will lift it
+# into a devantler-tech/reusable-workflows reusable workflow. Inline for now.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write # push the OCI artifact to GHCR
+  id-token: write # mint the OIDC token for cosign keyless signing (Fulcio + Rekor)
+
+jobs:
+  publish-manifests:
+    name: 🗳️ Publish manifests
+    runs-on: ubuntu-latest
+    env:
+      OCI_REPO: ghcr.io/devantler-tech/github-config/manifests
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Flux
+        # Same Flux setup action the org's reusable gitops workflows use.
+        uses: fluxcd/flux2/action@main
+
+      - name: ⚙️ Install cosign
+        env:
+          # renovate: datasource=github-releases depName=sigstore/cosign extractVersion=^v(?<version>.+)$
+          COSIGN_VERSION: "3.0.6"
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: "v${{ env.COSIGN_VERSION }}"
+
+      - name: 🔐 Configure GHCR auth
+        # Pre-create ~/.docker/config.json so flux push, cosign, and buildx all
+        # resolve GHCR credentials through the standard OCI keychain without an
+        # interactive login (avoids the "credentials stored unencrypted" warning).
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p ~/.docker
+          auth=$(printf '%s:%s' "$GITHUB_ACTOR" "$GITHUB_TOKEN" | base64 -w0)
+          printf '{"auths":{"ghcr.io":{"auth":"%s"}}}\n' "$auth" > ~/.docker/config.json
+
+      - name: 🗳️ Push & sign manifests artifact
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_name }}"
+          flux push artifact "oci://${OCI_REPO}:${TAG}" \
+            --path=./deploy \
+            --source="${{ github.repositoryUrl }}" \
+            --revision="${TAG}@sha1:${{ github.sha }}"
+          flux tag artifact "oci://${OCI_REPO}:${TAG}" --tag latest
+          # Resolve the pushed digest and sign by digest (keyless via OIDC).
+          DIGEST=$(docker buildx imagetools inspect "${OCI_REPO}:${TAG}" --format '{{ .Manifest.Digest }}')
+          cosign sign --yes "${OCI_REPO}@${DIGEST}"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -30,11 +30,12 @@ jobs:
       contents: read # checkout
       packages: write # push the OCI artifact to GHCR
       id-token: write # keyless cosign signing (Fulcio + Rekor via GitHub OIDC)
-    # NOTE: pinned to @main until reusable-workflows publishes a release that
-    # includes publish-manifests.yaml; then pin to the release commit SHA
-    # (Renovate manages this pin, as it does for publish-app.yaml elsewhere).
+    # Pinned to a commit SHA (zizmor blanket policy requires a hash). This is the
+    # reusable-workflows#319 branch head that introduces publish-manifests.yaml;
+    # re-pin to the release commit SHA once #319 merges and cuts a release
+    # (Renovate then manages this pin, as it does for publish-app.yaml elsewhere).
     # The platform verifier matches `@.+$`, so the ref does not affect cosign
     # verification.
-    uses: devantler-tech/reusable-workflows/.github/workflows/publish-manifests.yaml@main
+    uses: devantler-tech/reusable-workflows/.github/workflows/publish-manifests.yaml@44742c4f2093025a3dd2261479ccff9c8c893418 # reusable-workflows#319 (pre-release)
     with:
       oci-name: devantler-tech/github-config

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,75 +1,40 @@
 name: 🚀 CD
 
 # Publishes the org's declarative GitHub state (deploy/) as a cosign-signed OCI
-# artifact consumed by the platform cluster's `github-config` tenant. Unlike an
-# application repo, there is NO container image here — only manifests — so this
-# pushes a manifests-only artifact (no docker build). The OCI path is
-# `github-config` rather than the repo name, because `.github` is an invalid OCI
-# path component (leading dot).
+# artifact consumed by the platform cluster's `github-config` tenant. There is
+# NO container image here — only manifests — so it delegates to the shared
+# manifests-only publish workflow in devantler-tech/reusable-workflows (the
+# manifests-only sibling of publish-app.yaml).
 #
-# NOTE: a manifests-only publish is a generic pattern; a follow-up will lift it
-# into a devantler-tech/reusable-workflows reusable workflow. Inline for now.
+# The OCI path is `github-config` (not the repo name) because `.github` is an
+# invalid OCI path component (leading dot) — hence the oci-name override.
+#
+# Because signing runs INSIDE the reusable workflow, the cosign certificate
+# identity (OIDC subject) is that workflow's path —
+# https://github.com/devantler-tech/reusable-workflows/.github/workflows/publish-manifests.yaml@<ref>
+# — NOT this repo's cd.yaml. The platform `github-config` OCIRepository's
+# verify.matchOIDCIdentity.subject must match that (see
+# k8s/providers/hetzner/github/sync.yaml in devantler-tech/platform).
 
 on:
   push:
     tags:
       - "v*"
 
-permissions:
-  contents: read
-  packages: write # push the OCI artifact to GHCR
-  id-token: write # mint the OIDC token for cosign keyless signing (Fulcio + Rekor)
+permissions: {}
 
 jobs:
   publish-manifests:
     name: 🗳️ Publish manifests
-    runs-on: ubuntu-latest
-    env:
-      OCI_REPO: ghcr.io/devantler-tech/github-config/manifests
-    steps:
-      - name: 📑 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: ⚙️ Setup Flux
-        # renovate: datasource=github-releases depName=fluxcd/flux2
-        uses: fluxcd/flux2/action@1fd61a06264d71cf445ed55c4f14d401d26a1c64 # v2.8.8
-
-      - name: ⚙️ Install cosign
-        env:
-          # renovate: datasource=github-releases depName=sigstore/cosign extractVersion=^v(?<version>.+)$
-          COSIGN_VERSION: "3.0.6"
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: "v${{ env.COSIGN_VERSION }}"
-
-      - name: 🔐 Configure GHCR auth
-        # Pre-create ~/.docker/config.json so flux push, cosign, and buildx all
-        # resolve GHCR credentials through the standard OCI keychain without an
-        # interactive login (avoids the "credentials stored unencrypted" warning).
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p ~/.docker
-          auth=$(printf '%s:%s' "$GITHUB_ACTOR" "$GITHUB_TOKEN" | base64 -w0)
-          printf '{"auths":{"ghcr.io":{"auth":"%s"}}}\n' "$auth" > ~/.docker/config.json
-
-      - name: 🗳️ Push & sign manifests artifact
-        # github.* values are passed via env (never interpolated into the script
-        # body) so an attacker-controllable expansion can't inject shell code.
-        env:
-          TAG: ${{ github.ref_name }}
-          SRC_URL: ${{ github.repositoryUrl }}
-          COMMIT_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          flux push artifact "oci://${OCI_REPO}:${TAG}" \
-            --path=./deploy \
-            --source="${SRC_URL}" \
-            --revision="${TAG}@sha1:${COMMIT_SHA}"
-          flux tag artifact "oci://${OCI_REPO}:${TAG}" --tag latest
-          # Resolve the pushed digest and sign by digest (keyless via OIDC).
-          DIGEST=$(docker buildx imagetools inspect "${OCI_REPO}:${TAG}" --format '{{ .Manifest.Digest }}')
-          cosign sign --yes "${OCI_REPO}@${DIGEST}"
+    permissions:
+      contents: read # checkout
+      packages: write # push the OCI artifact to GHCR
+      id-token: write # keyless cosign signing (Fulcio + Rekor via GitHub OIDC)
+    # NOTE: pinned to @main until reusable-workflows publishes a release that
+    # includes publish-manifests.yaml; then pin to the release commit SHA
+    # (Renovate manages this pin, as it does for publish-app.yaml elsewhere).
+    # The platform verifier matches `@.+$`, so the ref does not affect cosign
+    # verification.
+    uses: devantler-tech/reusable-workflows/.github/workflows/publish-manifests.yaml@main
+    with:
+      oci-name: devantler-tech/github-config

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -33,8 +33,8 @@ jobs:
           persist-credentials: false
 
       - name: ⚙️ Setup Flux
-        # Same Flux setup action the org's reusable gitops workflows use.
-        uses: fluxcd/flux2/action@main
+        # renovate: datasource=github-releases depName=fluxcd/flux2
+        uses: fluxcd/flux2/action@1fd61a06264d71cf445ed55c4f14d401d26a1c64 # v2.8.8
 
       - name: ⚙️ Install cosign
         env:
@@ -57,13 +57,18 @@ jobs:
           printf '{"auths":{"ghcr.io":{"auth":"%s"}}}\n' "$auth" > ~/.docker/config.json
 
       - name: 🗳️ Push & sign manifests artifact
+        # github.* values are passed via env (never interpolated into the script
+        # body) so an attacker-controllable expansion can't inject shell code.
+        env:
+          TAG: ${{ github.ref_name }}
+          SRC_URL: ${{ github.repositoryUrl }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          TAG="${{ github.ref_name }}"
           flux push artifact "oci://${OCI_REPO}:${TAG}" \
             --path=./deploy \
-            --source="${{ github.repositoryUrl }}" \
-            --revision="${TAG}@sha1:${{ github.sha }}"
+            --source="${SRC_URL}" \
+            --revision="${TAG}@sha1:${COMMIT_SHA}"
           flux tag artifact "oci://${OCI_REPO}:${TAG}" --tag latest
           # Resolve the pushed digest and sign by digest (keyless via OIDC).
           DIGEST=$(docker buildx imagetools inspect "${OCI_REPO}:${TAG}" --format '{{ .Manifest.Digest }}')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,43 @@
+name: CI
+
+# Validates the declarative GitHub state in deploy/ on every PR, and reports the
+# `CI - Required Checks` status the org ruleset requires before merge. (cd.yaml
+# only runs on v* tags, so without this no PR-time required check is produced and
+# the PR stays merge-BLOCKED.)
+
+on:
+  pull_request:
+  merge_group:
+
+permissions: {}
+
+jobs:
+  validate-manifests:
+    name: 🧹 Validate manifests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧹 Validate deploy/ kustomize build
+        # kubectl (with built-in kustomize) is preinstalled on the runner. A
+        # successful build proves the manifests are well-formed; the Crossplane
+        # CRDs are applied/validated on-cluster, not here.
+        run: kubectl kustomize deploy/ > /dev/null
+
+  ci-required-checks:
+    name: CI - Required Checks
+    runs-on: ubuntu-latest
+    needs: [validate-manifests]
+    if: always()
+    permissions: {}
+    steps:
+      - name: 📊 Evaluate job results
+        uses: devantler-tech/actions/aggregate-job-checks@8ce19528eda1ef50f3d028b685c53aebaed6ae62 # v5.4.1
+        with:
+          job-results: >-
+            ${{ needs.validate-manifests.result }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,22 @@
+# `deploy/` — declarative GitHub state
+
+This directory is the source of truth for the devantler-tech org's GitHub
+configuration, expressed as [Crossplane](https://crossplane.io) managed
+resources (via
+[provider-upjet-github](https://github.com/crossplane-contrib/provider-upjet-github)).
+
+On every `v*` tag, [`cd.yaml`](../.github/workflows/cd.yaml) publishes this
+directory as a **cosign-signed OCI artifact** to
+`ghcr.io/devantler-tech/github-config/manifests`. The
+[platform](https://github.com/devantler-tech/platform) cluster onboards it as
+the **`github-config` tenant**: it verifies the signature, then Flux + Crossplane
+reconcile the live GitHub org to match these manifests — including reverting
+out-of-band changes made in the GitHub UI.
+
+- `repositories/` — one `Repository` per managed repo.
+
+See the platform repo's
+[`docs/github-management.md`](https://github.com/devantler-tech/platform/blob/main/docs/github-management.md)
+for the architecture, the GitHub App credential setup, and the **Observe-first**
+adoption flow for bringing an existing repository under management without any
+risk of recreating or deleting it.

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,10 @@
+# Root of the manifests artifact published to
+# oci://ghcr.io/devantler-tech/github-config/manifests and applied by the
+# platform's `github-config` tenant Kustomization (path: .). It carries the
+# devantler-tech org's desired GitHub state as Crossplane managed resources.
+# The target namespace (github-config) is injected by the platform-side
+# Kustomization's targetNamespace, so manifests here stay namespace-agnostic.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - repositories/

--- a/deploy/repositories/ksail.yaml
+++ b/deploy/repositories/ksail.yaml
@@ -1,0 +1,15 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: ksail
+  annotations:
+    # Binds this resource to the EXISTING devantler-tech/ksail repository
+    # (owner comes from the ProviderConfig credentials).
+    crossplane.io/external-name: ksail
+spec:
+  # Observe-only while adopting — see repositories/kustomization.yaml.
+  managementPolicies: ["Observe"]
+  forProvider: {}
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -1,0 +1,12 @@
+# One file per managed repository. Adoption is Observe-first: a repo starts with
+# managementPolicies: ["Observe"] (read-only — Crossplane mirrors live state into
+# status.atProvider and never writes), then forProvider is backfilled and the
+# policy promoted to the full set EXCEPT Delete. Namespaced managed resources
+# have no deletionPolicy; omitting Delete is what guarantees Crossplane can never
+# delete a real GitHub repository. See devantler-tech/platform
+# docs/github-management.md for the full adoption flow.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - platform.yaml
+  - ksail.yaml

--- a/deploy/repositories/platform.yaml
+++ b/deploy/repositories/platform.yaml
@@ -1,0 +1,17 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: platform
+  annotations:
+    # Binds this resource to the EXISTING devantler-tech/platform repository
+    # (owner comes from the ProviderConfig credentials).
+    crossplane.io/external-name: platform
+spec:
+  # Observe-only while adopting: Crossplane fills status.atProvider and never
+  # writes to GitHub. Backfill forProvider from status.atProvider, then promote
+  # to ["Observe","Create","Update","LateInitialize"] (everything except Delete).
+  managementPolicies: ["Observe"]
+  forProvider: {}
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default


### PR DESCRIPTION
## What

Adds a `deploy/` directory holding the devantler-tech org's GitHub configuration as **Crossplane managed resources**, and a workflow to publish it as a **cosign-signed OCI artifact**. The [platform](https://github.com/devantler-tech/platform) cluster onboards this repo as the **`github-config` tenant** ([platform#2039](https://github.com/devantler-tech/platform/pull/2039)) — it verifies the signature, then Flux + Crossplane reconcile the live org to match these manifests (and revert out-of-band UI edits). Goal: manage GitHub declaratively instead of via the UI.

## Contents

- `deploy/repositories/{platform,ksail}.yaml` — the first managed repos as namespaced `Repository` resources (`repo.github.m.upbound.io/v1alpha1`), **Observe-first** (`managementPolicies: [\"Observe\"]`): read-only adoption that mirrors live state into `status.atProvider` and never writes — zero risk of recreating or deleting the real repos. Namespaced MRs have no `deletionPolicy`; "never delete" is later expressed by omitting `Delete` from `managementPolicies`.
- `.github/workflows/cd.yaml` — on `v*` tags, publishes `deploy/` as a cosign-signed OCI artifact to `ghcr.io/devantler-tech/github-config/manifests` (manifests-only — no container image). The OCI name is `github-config` because `.github` is an invalid OCI path component (leading dot); the platform's `OCIRepository` cosign-verifies this workflow's identity.

## How it fits together

| | |
|---|---|
| Desired state (this repo) | `deploy/` managed resources |
| Engine + tenant wiring (platform) | Crossplane core + provider-upjet-github + the `github-config` namespace/SA/Role + namespaced `ProviderConfig` + cosign-verified `OCIRepository`/`Kustomization` |
| Credentials | GitHub App in OpenBao (`infrastructure/github/app`), materialized via ESO |

Namespaced (Crossplane v2) managed resources let the platform apply these with a **namespace-scoped tenant ServiceAccount + plain Role** — no cluster RBAC — so `.github` is a genuinely isolated tenant.

## Adoption flow (after merge + platform setup)

1. Tag a `v*` release → artifact published + signed.
2. Platform's `github-config` tenant pulls + verifies it; the two repos reconcile in Observe mode; `status.atProvider` mirrors live GitHub.
3. Backfill `spec.forProvider`, promote `managementPolicies` to all-except-`Delete`, then roll the rest of the org over incrementally.

See platform [`docs/github-management.md`](https://github.com/devantler-tech/platform/blob/claude/github-crossplane/docs/github-management.md). **Gated on the maintainer** creating the org GitHub App + seeding its credentials (details in that doc / the platform PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)