### PR TITLE
ci: scope stale-repos App token to least privilege

### DIFF
--- a/.github/workflows/stale-repository-identifier.yaml
+++ b/.github/workflows/stale-repository-identifier.yaml
@@ -20,6 +20,12 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Least-privilege scope (zizmor github-app): without these the token
+          # inherits all of the App's installation permissions. stale-repos only
+          # reads repo/PR/release activity and opens a report issue.
+          permission-contents: read
+          permission-pull-requests: read
+          permission-issues: write
 
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What

Adds least-privilege `permission-*` inputs to the `actions/create-github-app-token` step in `stale-repository-identifier.yaml`. Without them, the installation token inherits **all** of the App's permissions (zizmor `github-app` finding).

Scopes the token to exactly what the workflow uses:
- `permission-contents: read` + `permission-pull-requests: read` — stale-repos reads repo/PR/release activity
- `permission-issues: write` — opens the stale-report issue

## Context

This hardening was written during devantler-tech/.github#39 but landed on that branch *after* it was squash-merged, so it never reached `main` (the alert was PR-surfaced only, not active on `main`). This is the focused follow-up to land it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)