### PR TITLE
feat(deploy): own the GitHub App credential ExternalSecret + ProviderConfig

### DIFF
--- a/deploy/external-secret.yaml
+++ b/deploy/external-secret.yaml
@@ -1,0 +1,43 @@
+# Materializes the provider-upjet-github credentials Secret from OpenBao.
+# Tenant-owned (applied by the github-config app's own ServiceAccount) and reads
+# through the platform-provisioned NAMESPACED SecretStore `openbao` — NOT the
+# shared cluster store — whose dedicated `github-config` Vault role is scoped to
+# secret/data/infrastructure/github/* only. namespace is omitted on purpose: the
+# platform tenant Kustomization injects it via targetNamespace (= github-config).
+#
+# The provider expects ONE JSON document ({"app_auth":[…],"owner":…}) whose
+# pem_file value carries \n-escaped newlines — the template builds it from the
+# three plain keys (toJson does the escaping), so the PEM lives in OpenBao as a
+# normal multiline string. The values are placeholders until the maintainer
+# overwrites secret/infrastructure/github/app in OpenBao (see the platform
+# docs/github-management.md).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-app-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: SecretStore
+  target:
+    name: github-app-credentials
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        credentials: '{"app_auth":[{"id":"{{ .app_id }}","installation_id":"{{ .installation_id }}","pem_file":{{ .pem | toJson }}}],"owner":"devantler-tech"}'
+  data:
+    - secretKey: app_id
+      remoteRef:
+        key: infrastructure/github/app
+        property: app_id
+    - secretKey: installation_id
+      remoteRef:
+        key: infrastructure/github/app
+        property: installation_id
+    - secretKey: pem
+      remoteRef:
+        key: infrastructure/github/app
+        property: pem

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -7,4 +7,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # Tenant-owned auth wiring: the namespaced ProviderConfig + the GitHub App
+  # credential ExternalSecret (read via the platform-provisioned namespaced
+  # SecretStore). See the platform repo's docs/github-management.md.
+  - external-secret.yaml
+  - provider-config.yaml
   - repositories/

--- a/deploy/provider-config.yaml
+++ b/deploy/provider-config.yaml
@@ -1,0 +1,18 @@
+# Namespaced ProviderConfig (Crossplane v2): authenticates provider-upjet-github
+# against the devantler-tech org as a GitHub App. Tenant-owned (applied by the
+# github-config app's ServiceAccount). It is referenced by the namespaced
+# Repository/… managed resources in this same namespace. The credentials Secret
+# is local (same namespace), materialized by external-secret.yaml from OpenBao.
+# namespace is omitted on purpose — the platform tenant Kustomization injects it
+# via targetNamespace (= github-config). The github.m.upbound.io CRD is installed
+# by the provider package (platform infrastructure layer).
+apiVersion: github.m.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      name: github-app-credentials
+      key: credentials


### PR DESCRIPTION
## What

Moves the **tenant-specific** GitHub auth wiring out of the platform repo and into this repo's `deploy/` artifact, so the platform only provisions generic scaffolding (namespace, SA, RBAC, and a **namespaced** SecretStore). Pairs with platform [#2039](https://github.com/devantler-tech/platform/pull/2039).

- `deploy/external-secret.yaml` — the `github-app-credentials` ExternalSecret, now reading through the platform-provisioned **namespaced SecretStore** `openbao` (a dedicated `github-config` Vault role scoped to `secret/data/infrastructure/github/*` only — **not** the broad cluster-scoped store).
- `deploy/provider-config.yaml` — the namespaced `github.m.upbound.io` ProviderConfig.

`namespace` is omitted on both; the platform tenant Kustomization injects `github-config` via `targetNamespace` (same as the Repository MRs). Applied by the app's own ServiceAccount, whose Role was extended (platform side) with verbs on `external-secrets.io` + `github.m.upbound.io`.

## Why

Two maintainer asks: (1) these manifests are tenant-specific, not platform-specific, so they belong here; (2) the tenant should use a **namespace-scoped SecretStore** — read access to the cluster SecretStore (which can reach every infra + app path) was too broad a privilege. This mirrors the wedding-app tenant pattern.

## Rollout

Merge + tag a new `v*` release so the published `github-config` artifact includes these, alongside platform #2039. Until the maintainer overwrites the OpenBao placeholders at `secret/infrastructure/github/app`, the credential is non-working and the provider's auth simply fails (isolated to the leaf apps layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)