### PR TITLE
fix(deploy): set ProviderConfig secretRef.namespace (required field)

### DIFF
--- a/deploy/provider-config.yaml
+++ b/deploy/provider-config.yaml
@@ -2,10 +2,13 @@
 # against the devantler-tech org as a GitHub App. Tenant-owned (applied by the
 # github-config app's ServiceAccount). It is referenced by the namespaced
 # Repository/… managed resources in this same namespace. The credentials Secret
-# is local (same namespace), materialized by external-secret.yaml from OpenBao.
-# namespace is omitted on purpose — the platform tenant Kustomization injects it
-# via targetNamespace (= github-config). The github.m.upbound.io CRD is installed
-# by the provider package (platform infrastructure layer).
+# is materialized by external-secret.yaml from OpenBao.
+#
+# The resource's own namespace is omitted on purpose — the platform tenant
+# Kustomization injects it via targetNamespace (= github-config). But
+# spec.credentials.secretRef.namespace is a REQUIRED field (the CRD enforces it
+# even for a namespaced ProviderConfig) and is a value, not the resource
+# namespace, so it must be set explicitly to where the credential Secret lives.
 apiVersion: github.m.upbound.io/v1beta1
 kind: ProviderConfig
 metadata:
@@ -14,5 +17,6 @@ spec:
   credentials:
     source: Secret
     secretRef:
+      namespace: github-config
       name: github-app-credentials
       key: credentials


### PR DESCRIPTION
## What

The namespaced `github.m.upbound.io` ProviderConfig requires `spec.credentials.secretRef.namespace` (the CRD enforces it even for a namespaced config). It was omitted in #41, so the platform `github-config` tenant's Flux apply failed dry-run:

```
ProviderConfig.github.m.upbound.io "default" is invalid: spec.credentials.secretRef.namespace: Required value
```

Because Flux applies the artifact atomically, that one invalid resource blocked the **entire** apply — so the ExternalSecret and Repository MRs never reconciled either (verified live: OCIRepository at v1.1.0 but sync stuck, MRs `SYNCED=False` "ProviderConfig 'default' not found").

## Fix

Set `secretRef.namespace: github-config` explicitly. It's a field value (not the resource namespace), so the platform tenant Kustomization's `targetNamespace` can't inject it. Points at where `external-secret.yaml` materializes the credential Secret.

Found while verifying the live controller after the GitHub App credentials were seeded in OpenBao. Needs a `v1.1.1` tag after merge to republish the artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)