### PR TITLE
feat(deploy): bring the maintenance repo under active management

### DIFF
--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -10,3 +10,6 @@ kind: Kustomization
 resources:
   - platform.yaml
   - ksail.yaml
+  # First repo under ACTIVE management (managementPolicies all-except-Delete);
+  # platform + ksail remain Observe-only.
+  - maintenance.yaml

--- a/deploy/repositories/maintenance.yaml
+++ b/deploy/repositories/maintenance.yaml
@@ -1,0 +1,36 @@
+# First repo brought under ACTIVE management (everything except Delete), as a
+# low-risk pilot. forProvider mirrors the repo's CURRENT settings, so taking over
+# management changes nothing; LateInitialize adopts any unset field (e.g.
+# visibility) from the observed repo, and omitting Delete means deleting this CR
+# orphans — never deletes — the real repository. The high-stakes `visibility`
+# field is intentionally left to LateInitialize (never hard-set here) and
+# `archived` is pinned false so it can never accidentally archive the repo.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: maintenance
+  annotations:
+    crossplane.io/external-name: maintenance
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    description: "CLI tools for GitHub organization maintenance"
+    hasIssues: true
+    hasWiki: true
+    hasProjects: true
+    hasDownloads: true
+    allowMergeCommit: true
+    allowSquashMerge: true
+    allowRebaseMerge: true
+    allowAutoMerge: true
+    allowUpdateBranch: true
+    deleteBranchOnMerge: false
+    isTemplate: false
+    archived: false
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default


### PR DESCRIPTION
## What

Pilots the first repo promoted from **Observe-only** to **active management** — `maintenance` (a low-criticality CLI-tools repo; platform + ksail stay Observe-only).

- `managementPolicies: [Observe, Create, Update, LateInitialize]` — everything **except Delete** (deleting the CR orphans, never deletes the repo).
- `forProvider` **mirrors the repo's current settings**, so taking over management is a **no-op** (verified against the live repo before/after).
- `visibility` is intentionally left to **LateInitialize** (never hard-set), and `archived` pinned `false`, so management can't accidentally change visibility or archive the repo.

Follows the adoption flow in the platform `docs/github-management.md`. Needs a `v1.1.2` tag after merge to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)