### PR TITLE
fix(deploy): add forProvider.name to managed maintenance Repository

### DIFF
--- a/deploy/repositories/maintenance.yaml
+++ b/deploy/repositories/maintenance.yaml
@@ -18,6 +18,9 @@ spec:
     - Update
     - LateInitialize
   forProvider:
+    # Required once managementPolicies includes Create/Update (Observe-only
+    # didn't enforce it); must equal the external-name / repo name.
+    name: maintenance
     description: "CLI tools for GitHub organization maintenance"
     hasIssues: true
     hasWiki: true


### PR DESCRIPTION
Promoting a Repository to managed (managementPolicies with Create/Update) makes `spec.forProvider.name` required — Observe-only didn't enforce it. Its absence failed the platform tenant's Flux dry-run and blocked the v1.1.2 apply (maintenance MR never created; platform/ksail unaffected). Set `name: maintenance` (= external-name). Needs a v1.1.3 tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)