### PR TITLE
feat(deploy): manage public repos with squash-only merge policy (phase 1)

### DIFF
--- a/deploy/repositories/dotnet-template.yaml
+++ b/deploy/repositories/dotnet-template.yaml
@@ -1,0 +1,22 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: dotnet-template
+  annotations:
+    crossplane.io/external-name: dotnet-template
+spec:
+  # Managed (all except Delete). forProvider is intentionally minimal: only the
+  # required name is set here; the org-wide squash-only merge policy comes from
+  # the shared patch in kustomization.yaml, and every other setting is adopted
+  # unchanged from the live repo via LateInitialize. So the only changes this
+  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: dotnet-template
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/gitops-tenant-template.yaml
+++ b/deploy/repositories/gitops-tenant-template.yaml
@@ -1,0 +1,22 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: gitops-tenant-template
+  annotations:
+    crossplane.io/external-name: gitops-tenant-template
+spec:
+  # Managed (all except Delete). forProvider is intentionally minimal: only the
+  # required name is set here; the org-wide squash-only merge policy comes from
+  # the shared patch in kustomization.yaml, and every other setting is adopted
+  # unchanged from the live repo via LateInitialize. So the only changes this
+  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: gitops-tenant-template
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/go-template.yaml
+++ b/deploy/repositories/go-template.yaml
@@ -1,0 +1,22 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: go-template
+  annotations:
+    crossplane.io/external-name: go-template
+spec:
+  # Managed (all except Delete). forProvider is intentionally minimal: only the
+  # required name is set here; the org-wide squash-only merge policy comes from
+  # the shared patch in kustomization.yaml, and every other setting is adopted
+  # unchanged from the live repo via LateInitialize. So the only changes this
+  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: go-template
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/homebrew-tap.yaml
+++ b/deploy/repositories/homebrew-tap.yaml
@@ -1,0 +1,22 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: homebrew-tap
+  annotations:
+    crossplane.io/external-name: homebrew-tap
+spec:
+  # Managed (all except Delete). forProvider is intentionally minimal: only the
+  # required name is set here; the org-wide squash-only merge policy comes from
+  # the shared patch in kustomization.yaml, and every other setting is adopted
+  # unchanged from the live repo via LateInitialize. So the only changes this
+  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: homebrew-tap
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -1,15 +1,51 @@
 # One file per managed repository. Adoption is Observe-first: a repo starts with
 # managementPolicies: ["Observe"] (read-only — Crossplane mirrors live state into
-# status.atProvider and never writes), then forProvider is backfilled and the
-# policy promoted to the full set EXCEPT Delete. Namespaced managed resources
-# have no deletionPolicy; omitting Delete is what guarantees Crossplane can never
-# delete a real GitHub repository. See devantler-tech/platform
-# docs/github-management.md for the full adoption flow.
+# status.atProvider and never writes), then forProvider is set and the policy
+# promoted to the full set EXCEPT Delete. Namespaced managed resources have no
+# deletionPolicy; omitting Delete is what guarantees Crossplane can never delete
+# a real GitHub repository. See devantler-tech/platform docs/github-management.md.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # Observe-only (read-only mirror) — promoted to managed in a later phase.
   - platform.yaml
   - ksail.yaml
-  # First repo under ACTIVE management (managementPolicies all-except-Delete);
-  # platform + ksail remain Observe-only.
+  # Actively managed (managementPolicies all-except-Delete).
   - maintenance.yaml
+  - skills.yaml
+  - plugins.yaml
+  - unifi.yaml
+  - gitops-tenant-template.yaml
+  - platform-template.yaml
+  - go-template.yaml
+  - dotnet-template.yaml
+  - homebrew-tap.yaml
+# Org-wide merge policy applied to EVERY Repository: squash-only (merge commits
+# and rebase disabled), auto-merge allowed, head branches auto-deleted, and
+# always-suggest-updating-PR-branches. Keeping it here (not per-file) makes it
+# the single source of truth and auto-applies to every future repo. It is inert
+# on the Observe-only resources (platform/ksail) until they are promoted.
+patches:
+  - target:
+      group: repo.github.m.upbound.io
+      version: v1alpha1
+      kind: Repository
+    patch: |-
+      - op: add
+        path: /spec/forProvider/allowSquashMerge
+        value: true
+      - op: add
+        path: /spec/forProvider/allowMergeCommit
+        value: false
+      - op: add
+        path: /spec/forProvider/allowRebaseMerge
+        value: false
+      - op: add
+        path: /spec/forProvider/allowAutoMerge
+        value: true
+      - op: add
+        path: /spec/forProvider/allowUpdateBranch
+        value: true
+      - op: add
+        path: /spec/forProvider/deleteBranchOnMerge
+        value: true

--- a/deploy/repositories/maintenance.yaml
+++ b/deploy/repositories/maintenance.yaml
@@ -1,10 +1,8 @@
-# First repo brought under ACTIVE management (everything except Delete), as a
-# low-risk pilot. forProvider mirrors the repo's CURRENT settings, so taking over
-# management changes nothing; LateInitialize adopts any unset field (e.g.
-# visibility) from the observed repo, and omitting Delete means deleting this CR
-# orphans — never deletes — the real repository. The high-stakes `visibility`
-# field is intentionally left to LateInitialize (never hard-set here) and
-# `archived` is pinned false so it can never accidentally archive the repo.
+# First repo brought under ACTIVE management (everything except Delete). The
+# merge policy (squash-only + auto-merge + auto-delete branches + suggest-update)
+# now comes from the shared patch in kustomization.yaml, so it is not repeated
+# here. `archived` is pinned false so management can never accidentally archive
+# the repo; `visibility` is intentionally left to LateInitialize (never hard-set).
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: Repository
 metadata:
@@ -26,12 +24,6 @@ spec:
     hasWiki: true
     hasProjects: true
     hasDownloads: true
-    allowMergeCommit: true
-    allowSquashMerge: true
-    allowRebaseMerge: true
-    allowAutoMerge: true
-    allowUpdateBranch: true
-    deleteBranchOnMerge: false
     isTemplate: false
     archived: false
   providerConfigRef:

--- a/deploy/repositories/platform-template.yaml
+++ b/deploy/repositories/platform-template.yaml
@@ -1,0 +1,22 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: platform-template
+  annotations:
+    crossplane.io/external-name: platform-template
+spec:
+  # Managed (all except Delete). forProvider is intentionally minimal: only the
+  # required name is set here; the org-wide squash-only merge policy comes from
+  # the shared patch in kustomization.yaml, and every other setting is adopted
+  # unchanged from the live repo via LateInitialize. So the only changes this
+  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: platform-template
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/plugins.yaml
+++ b/deploy/repositories/plugins.yaml
@@ -1,0 +1,22 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: plugins
+  annotations:
+    crossplane.io/external-name: plugins
+spec:
+  # Managed (all except Delete). forProvider is intentionally minimal: only the
+  # required name is set here; the org-wide squash-only merge policy comes from
+  # the shared patch in kustomization.yaml, and every other setting is adopted
+  # unchanged from the live repo via LateInitialize. So the only changes this
+  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: plugins
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/skills.yaml
+++ b/deploy/repositories/skills.yaml
@@ -1,0 +1,22 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: skills
+  annotations:
+    crossplane.io/external-name: skills
+spec:
+  # Managed (all except Delete). forProvider is intentionally minimal: only the
+  # required name is set here; the org-wide squash-only merge policy comes from
+  # the shared patch in kustomization.yaml, and every other setting is adopted
+  # unchanged from the live repo via LateInitialize. So the only changes this
+  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: skills
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/unifi.yaml
+++ b/deploy/repositories/unifi.yaml
@@ -1,0 +1,22 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: unifi
+  annotations:
+    crossplane.io/external-name: unifi
+spec:
+  # Managed (all except Delete). forProvider is intentionally minimal: only the
+  # required name is set here; the org-wide squash-only merge policy comes from
+  # the shared patch in kustomization.yaml, and every other setting is adopted
+  # unchanged from the live repo via LateInitialize. So the only changes this
+  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: unifi
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default


### PR DESCRIPTION
## What

Phase 1 of bringing the org under management with your squash-only merge policy. Adds a **shared kustomize patch** enforcing on every `Repository`:

| Setting | Value |
|---|---|
| `allowSquashMerge` | true |
| `allowMergeCommit` | **false** |
| `allowRebaseMerge` | **false** |
| `allowAutoMerge` | true |
| `allowUpdateBranch` | true |
| `deleteBranchOnMerge` | true |

Brings **8 low-risk public repos** under active management: skills, plugins, unifi, gitops-tenant-template, platform-template, go-template, dotnet-template, homebrew-tap. Each uses a **minimal `forProvider` (name only)** — every other setting is adopted unchanged via `LateInitialize`, so the **only** changes are the merge policy (+ a cosmetic `homepage` null→""). `maintenance`'s merge fields fold into the shared patch.

## Carefully

- `platform`/`ksail` stay **Observe-only** (the patch is inert on them) — they + the private repos come in **phase 2** after this validates.
- archived `data-product` excluded (writes to archived repos fail).
- compatible with the org's "require linear history" ruleset (squash = linear).

Needs a `v1.2.0` tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)