### PR TITLE
feat(deploy): manage platform, ksail + private repos (phase 2, squash-only)

### DIFF
--- a/deploy/repositories/ascoachingogvaner.yaml
+++ b/deploy/repositories/ascoachingogvaner.yaml
@@ -1,0 +1,23 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: ascoachingogvaner
+  annotations:
+    crossplane.io/external-name: ascoachingogvaner
+spec:
+  # Actively managed (everything except Delete). Merge policy from the shared
+  # patch; LateInitialize adopts every other setting unchanged. PRIVATE repo:
+  # visibility is pinned private explicitly (never left to inference) so
+  # management can never expose it, and archived false so it can't be archived.
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: ascoachingogvaner
+    visibility: private
+    archived: false
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/fleet-gitops.yaml
+++ b/deploy/repositories/fleet-gitops.yaml
@@ -1,0 +1,23 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: fleet-gitops
+  annotations:
+    crossplane.io/external-name: fleet-gitops
+spec:
+  # Actively managed (everything except Delete). Merge policy from the shared
+  # patch; LateInitialize adopts every other setting unchanged. PRIVATE repo:
+  # visibility is pinned private explicitly (never left to inference) so
+  # management can never expose it, and archived false so it can't be archived.
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: fleet-gitops
+    visibility: private
+    archived: false
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/ksail.yaml
+++ b/deploy/repositories/ksail.yaml
@@ -7,9 +7,18 @@ metadata:
     # (owner comes from the ProviderConfig credentials).
     crossplane.io/external-name: ksail
 spec:
-  # Observe-only while adopting — see repositories/kustomization.yaml.
-  managementPolicies: ["Observe"]
-  forProvider: {}
+  # Actively managed (everything except Delete). Merge policy from the shared
+  # patch; LateInitialize adopts the rest. visibility pinned public + archived
+  # false so management can never flip visibility or archive this repo.
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: ksail
+    visibility: public
+    archived: false
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -7,10 +7,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # Observe-only (read-only mirror) — promoted to managed in a later phase.
+  # Actively managed (managementPolicies all-except-Delete). Every non-archived
+  # org repo; the shared merge-policy patch below applies to all of them.
   - platform.yaml
   - ksail.yaml
-  # Actively managed (managementPolicies all-except-Delete).
   - maintenance.yaml
   - skills.yaml
   - plugins.yaml
@@ -20,11 +20,14 @@ resources:
   - go-template.yaml
   - dotnet-template.yaml
   - homebrew-tap.yaml
+  # Private repos.
+  - ascoachingogvaner.yaml
+  - wedding-app.yaml
+  - fleet-gitops.yaml
 # Org-wide merge policy applied to EVERY Repository: squash-only (merge commits
 # and rebase disabled), auto-merge allowed, head branches auto-deleted, and
 # always-suggest-updating-PR-branches. Keeping it here (not per-file) makes it
-# the single source of truth and auto-applies to every future repo. It is inert
-# on the Observe-only resources (platform/ksail) until they are promoted.
+# the single source of truth and auto-applies to every future repo.
 patches:
   - target:
       group: repo.github.m.upbound.io

--- a/deploy/repositories/platform.yaml
+++ b/deploy/repositories/platform.yaml
@@ -7,11 +7,19 @@ metadata:
     # (owner comes from the ProviderConfig credentials).
     crossplane.io/external-name: platform
 spec:
-  # Observe-only while adopting: Crossplane fills status.atProvider and never
-  # writes to GitHub. Backfill forProvider from status.atProvider, then promote
-  # to ["Observe","Create","Update","LateInitialize"] (everything except Delete).
-  managementPolicies: ["Observe"]
-  forProvider: {}
+  # Actively managed (everything except Delete). The merge policy comes from the
+  # shared patch in kustomization.yaml; LateInitialize adopts every other setting
+  # unchanged. visibility is pinned public and archived false explicitly so
+  # management can never flip visibility or archive this repo.
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: platform
+    visibility: public
+    archived: false
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/wedding-app.yaml
+++ b/deploy/repositories/wedding-app.yaml
@@ -1,0 +1,23 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: wedding-app
+  annotations:
+    crossplane.io/external-name: wedding-app
+spec:
+  # Actively managed (everything except Delete). Merge policy from the shared
+  # patch; LateInitialize adopts every other setting unchanged. PRIVATE repo:
+  # visibility is pinned private explicitly (never left to inference) so
+  # management can never expose it, and archived false so it can't be archived.
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: wedding-app
+    visibility: private
+    archived: false
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default


### PR DESCRIPTION
## What

Phase 2 — completes org-wide management. Promotes **platform** + **ksail** from Observe-only to actively managed, and brings the **private** repos (ascoachingogvaner, wedding-app, fleet-gitops) under management. All inherit the shared squash-only merge policy from phase 1.

## Carefully (private/critical repos)

- **visibility pinned explicitly** — `public` for platform/ksail, `private` for the 3 private repos — so management can **never** flip a private repo public. Verified in the rendered build (3× private, 2× public).
- `archived: false` pinned (can't accidentally archive).
- minimal `forProvider` otherwise → every non-merge setting adopted unchanged via LateInitialize; the **only** change is the merge policy (disable merge-commit/rebase where currently on; enable auto-delete on fleet-gitops) + a cosmetic `homepage` null→"".
- platform's SQUASH merge queue is unaffected (squash stays enabled).

After this, all 14 non-archived org repos are managed (data-product stays excluded as archived). Needs a `v1.3.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)