### PR TITLE
feat(deploy): rename skills->agent-skills, plugins->agent-plugins

### DIFF
--- a/deploy/repositories/plugins.yaml
+++ b/deploy/repositories/plugins.yaml
@@ -5,18 +5,19 @@ metadata:
   annotations:
     crossplane.io/external-name: plugins
 spec:
-  # Managed (all except Delete). forProvider is intentionally minimal: only the
-  # required name is set here; the org-wide squash-only merge policy comes from
-  # the shared patch in kustomization.yaml, and every other setting is adopted
-  # unchanged from the live repo via LateInitialize. So the only changes this
-  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  # RENAME plugins -> agent-plugins: forProvider.name is the new name while
+  # external-name stays the current repo ("plugins"), so Crossplane renames the
+  # repo IN PLACE (an Update, not a re-create) — GitHub keeps the old name as a
+  # redirect. external-name is updated to agent-plugins in a follow-up once the
+  # rename has reconciled. Squash-only merge policy still comes from the shared
+  # patch; everything else is adopted via LateInitialize.
   managementPolicies:
     - Observe
     - Create
     - Update
     - LateInitialize
   forProvider:
-    name: plugins
+    name: agent-plugins
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/skills.yaml
+++ b/deploy/repositories/skills.yaml
@@ -5,18 +5,19 @@ metadata:
   annotations:
     crossplane.io/external-name: skills
 spec:
-  # Managed (all except Delete). forProvider is intentionally minimal: only the
-  # required name is set here; the org-wide squash-only merge policy comes from
-  # the shared patch in kustomization.yaml, and every other setting is adopted
-  # unchanged from the live repo via LateInitialize. So the only changes this
-  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  # RENAME skills -> agent-skills: forProvider.name is the new name while
+  # external-name stays the current repo ("skills"), so Crossplane renames the
+  # repo IN PLACE (an Update, not a re-create) — GitHub keeps the old name as a
+  # redirect. external-name is updated to agent-skills in a follow-up once the
+  # rename has reconciled. Squash-only merge policy still comes from the shared
+  # patch; everything else is adopted via LateInitialize.
   managementPolicies:
     - Observe
     - Create
     - Update
     - LateInitialize
   forProvider:
-    name: skills
+    name: agent-skills
   providerConfigRef:
     kind: ProviderConfig
     name: default


### PR DESCRIPTION
## What

Renames the `skills` and `plugins` repos to `agent-skills` and `agent-plugins` declaratively, via the managed Crossplane Repository resources.

Done by changing `forProvider.name` to the new name while leaving `external-name` bound to the **current** repo — so Crossplane performs an **in-place rename** (Update), not a re-create. GitHub keeps the old names as redirects. `external-name` + file/metadata are cleaned up in a follow-up once the renames reconcile.

## Safe

- In-place Update, not Create → no duplicate/empty repos.
- managementPolicies excludes Delete → even on error, nothing is destructive.
- Not monorepo submodules; GitHub redirects keep existing references working (`projects/ksail/skills-lock.json` + some SKILL.md refs should be updated as a follow-up).

Needs a `v1.4.0` tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)