### PR TITLE
fix(deploy): org-enforced commit signoff + finish skills/plugins rename

### DIFF
--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -24,10 +24,15 @@ resources:
   - ascoachingogvaner.yaml
   - wedding-app.yaml
   - fleet-gitops.yaml
-# Org-wide merge policy applied to EVERY Repository: squash-only (merge commits
-# and rebase disabled), auto-merge allowed, head branches auto-deleted, and
-# always-suggest-updating-PR-branches. Keeping it here (not per-file) makes it
-# the single source of truth and auto-applies to every future repo.
+# Org-wide repo settings applied to EVERY Repository, single source of truth
+# (auto-applies to every future repo):
+#  - squash-only merge policy (merge commits + rebase disabled; auto-merge,
+#    auto-delete head branches, always-suggest-updating-PR-branches enabled).
+#  - webCommitSignoffRequired: true — the org ENFORCES commit signoff and it
+#    can't be disabled per-repo, so the provider must always send true (else an
+#    update PATCH gets 422 "Commit signoff is enforced ... and cannot be
+#    disabled"). The 12 already-adopted repos had this true via LateInitialize;
+#    pinning it here makes every repo's update self-consistent and robust.
 patches:
   - target:
       group: repo.github.m.upbound.io
@@ -51,4 +56,7 @@ patches:
         value: true
       - op: add
         path: /spec/forProvider/deleteBranchOnMerge
+        value: true
+      - op: add
+        path: /spec/forProvider/webCommitSignoffRequired
         value: true

--- a/deploy/repositories/plugins.yaml
+++ b/deploy/repositories/plugins.yaml
@@ -1,16 +1,15 @@
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: Repository
 metadata:
+  # NOTE: the k8s resource name stays "plugins" (historical) to avoid a
+  # prune/re-adopt cycle; it manages the renamed agent-plugins repo. external-name
+  # + forProvider.name are both agent-plugins now that the rename has reconciled.
   name: plugins
   annotations:
-    crossplane.io/external-name: plugins
+    crossplane.io/external-name: agent-plugins
 spec:
-  # RENAME plugins -> agent-plugins: forProvider.name is the new name while
-  # external-name stays the current repo ("plugins"), so Crossplane renames the
-  # repo IN PLACE (an Update, not a re-create) — GitHub keeps the old name as a
-  # redirect. external-name is updated to agent-plugins in a follow-up once the
-  # rename has reconciled. Squash-only merge policy still comes from the shared
-  # patch; everything else is adopted via LateInitialize.
+  # Manages the agent-plugins repo (renamed from plugins). Squash-only merge
+  # policy comes from the shared patch; everything else is adopted via LateInitialize.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/skills.yaml
+++ b/deploy/repositories/skills.yaml
@@ -1,16 +1,15 @@
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: Repository
 metadata:
+  # NOTE: the k8s resource name stays "skills" (historical) to avoid a
+  # prune/re-adopt cycle; it manages the renamed agent-skills repo. external-name
+  # + forProvider.name are both agent-skills now that the rename has reconciled.
   name: skills
   annotations:
-    crossplane.io/external-name: skills
+    crossplane.io/external-name: agent-skills
 spec:
-  # RENAME skills -> agent-skills: forProvider.name is the new name while
-  # external-name stays the current repo ("skills"), so Crossplane renames the
-  # repo IN PLACE (an Update, not a re-create) — GitHub keeps the old name as a
-  # redirect. external-name is updated to agent-skills in a follow-up once the
-  # rename has reconciled. Squash-only merge policy still comes from the shared
-  # patch; everything else is adopted via LateInitialize.
+  # Manages the agent-skills repo (renamed from skills). Squash-only merge policy
+  # comes from the shared patch; everything else is adopted via LateInitialize.
   managementPolicies:
     - Observe
     - Create


### PR DESCRIPTION
## What

Two things:
1. **Pin `webCommitSignoffRequired: true`** in the shared patch. The org enforces commit signoff and forbids disabling it per-repo, so the provider's update PATCH hit `422 "Commit signoff is enforced by the organization and cannot be disabled"` (it was sending `false`, the TF default for the unset field). This surfaced on the skills/plugins rename update; the other 12 repos had it `true` via LateInitialize. Pinning it makes every repo's update self-consistent.
2. **Finish the rename:** point the skills/plugins MRs' `external-name` at the now-renamed `agent-skills`/`agent-plugins` repos (k8s resource names kept stable to avoid a prune/re-adopt cycle).

Resolves the `Synced=False` on the two renamed MRs. Needs a `v1.4.1` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)