### PR TITLE
feat(deploy): manage issue labels declaratively across all repos

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -14,6 +14,10 @@ reconcile the live GitHub org to match these manifests — including reverting
 out-of-band changes made in the GitHub UI.
 
 - `repositories/` — one `Repository` per managed repo.
+- `teams/` — the `maintainers` team, its membership, and team → repo access.
+- `labels/` — one `IssueLabels` per managed repo declaring its canonical
+  triage/roadmap label taxonomy (authoritative: out-of-band label drift is
+  reverted).
 
 See the platform repo's
 [`docs/github-management.md`](https://github.com/devantler-tech/platform/blob/main/docs/github-management.md)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -15,9 +15,11 @@ out-of-band changes made in the GitHub UI.
 
 - `repositories/` — one `Repository` per managed repo.
 - `teams/` — the `maintainers` team, its membership, and team → repo access.
-- `labels/` — one `IssueLabels` per managed repo declaring its canonical
-  triage/roadmap label taxonomy (authoritative: out-of-band label drift is
-  reverted).
+- `labels/` — one `IssueLabels` per managed repo. The canonical org label
+  taxonomy lives once in `labels/kustomization.yaml` (a shared patch appended to
+  every repo); each `<repo>.yaml` adds only that repo's Dependabot/Renovate
+  ecosystem extras. Authoritative — out-of-band label drift is reverted. This is
+  the Crossplane replacement for the old EndBug/label-sync workflow.
 
 See the platform repo's
 [`docs/github-management.md`](https://github.com/devantler-tech/platform/blob/main/docs/github-management.md)

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -9,3 +9,4 @@ kind: Kustomization
 resources:
   - repositories/
   - teams/
+  - labels/

--- a/deploy/labels/agent-plugins.yaml
+++ b/deploy/labels/agent-plugins.yaml
@@ -1,14 +1,14 @@
-# Issue labels for devantler-tech/.github. The canonical org taxonomy (22 labels)
+# Issue labels for devantler-tech/agent-plugins. The canonical org taxonomy (22 labels)
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only .github's repo-specific extras (the dependency/ecosystem labels
+# file adds only agent-plugins's repo-specific extras (the dependency/ecosystem labels
 # Dependabot/Renovate apply), declared so the authoritative set doesn't churn
 # against the bots. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
-  name: dot-github
+  name: agent-plugins
   annotations:
-    crossplane.io/external-name: .github
+    crossplane.io/external-name: agent-plugins
 spec:
   managementPolicies:
     - Observe
@@ -16,9 +16,10 @@ spec:
     - Update
     - LateInitialize
   forProvider:
-    repository: .github
-    # No repo-specific extras; the shared patch supplies the full canonical set.
-    label: []
+    repository: agent-plugins
+    label:
+      - name: "dependencies"
+        color: "ededed"
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/labels/agent-skills.yaml
+++ b/deploy/labels/agent-skills.yaml
@@ -1,14 +1,14 @@
-# Issue labels for devantler-tech/.github. The canonical org taxonomy (22 labels)
+# Issue labels for devantler-tech/agent-skills. The canonical org taxonomy (22 labels)
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only .github's repo-specific extras (the dependency/ecosystem labels
+# file adds only agent-skills's repo-specific extras (the dependency/ecosystem labels
 # Dependabot/Renovate apply), declared so the authoritative set doesn't churn
 # against the bots. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
-  name: dot-github
+  name: agent-skills
   annotations:
-    crossplane.io/external-name: .github
+    crossplane.io/external-name: agent-skills
 spec:
   managementPolicies:
     - Observe
@@ -16,7 +16,7 @@ spec:
     - Update
     - LateInitialize
   forProvider:
-    repository: .github
+    repository: agent-skills
     # No repo-specific extras; the shared patch supplies the full canonical set.
     label: []
   providerConfigRef:

--- a/deploy/labels/ascoachingogvaner.yaml
+++ b/deploy/labels/ascoachingogvaner.yaml
@@ -1,0 +1,31 @@
+# Issue labels for devantler-tech/ascoachingogvaner. The canonical org taxonomy (22 labels)
+# is appended to every IssueLabels by the shared patch in kustomization.yaml; this
+# file adds only ascoachingogvaner's repo-specific extras (the dependency/ecosystem labels
+# Dependabot/Renovate apply), declared so the authoritative set doesn't churn
+# against the bots. See ../README.md.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: IssueLabels
+metadata:
+  name: ascoachingogvaner
+  annotations:
+    crossplane.io/external-name: ascoachingogvaner
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: ascoachingogvaner
+    label:
+      - name: "dependencies"
+        color: "0366d6"
+      - name: "docker"
+        color: "21ceff"
+      - name: "javascript"
+        color: "168700"
+      - name: "github_actions"
+        color: "000000"
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/labels/dot-github.yaml
+++ b/deploy/labels/dot-github.yaml
@@ -1,0 +1,87 @@
+# Issue labels for devantler-tech/.github — the org's declarative source-of-truth
+# repo. `IssueLabels` (provider-upjet-github, terraform github_issue_labels) is
+# AUTHORITATIVE: it manages the repo's COMPLETE label set, so any label not listed
+# here is removed on reconcile (this is the point — it reverts out-of-band label
+# drift, exactly like the rest of deploy/). `.github` currently has only `blocked`
+# (kept below), so first reconcile is purely additive.
+#
+# managementPolicies omit Delete: Crossplane can create/update the label set but
+# can never delete the IssueLabels resource's managed labels wholesale. The label
+# kind `issuelabels.repo.github.m.upbound.io` is already activated in the platform
+# ManagedResourceActivationPolicy and covered by the github-config tenant Role, so
+# no platform-side change is needed.
+#
+# This `label` list is the org's CANONICAL triage/roadmap taxonomy. Bring another
+# repo under management by adding `deploy/labels/<repo>.yaml` with the same
+# taxonomy — but first enumerate that repo's existing labels (incl. any in use on
+# open issues/PRs, and the `dependencies`/ecosystem labels Dependabot/Renovate
+# apply) so the authoritative set doesn't strip a label that's actively used.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: IssueLabels
+metadata:
+  name: dot-github
+  annotations:
+    # Binds to the existing devantler-tech/.github repository (owner comes from
+    # the ProviderConfig credentials); import id for github_issue_labels is the
+    # repository name.
+    crossplane.io/external-name: .github
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: .github
+    label:
+      # --- triage / roadmap taxonomy (the portfolio-wide convention) ---
+      - name: roadmap
+        color: "0e8a16"
+        description: Epic / theme-level roadmap item
+      - name: enhancement
+        color: "a2eeef"
+        description: New feature or improvement
+      - name: bug
+        color: "d73a4a"
+        description: Something isn't working
+      - name: documentation
+        color: "0075ca"
+        description: Improvements or additions to documentation
+      - name: refactor
+        color: "fbca04"
+        description: Behaviour-preserving code-quality change
+      - name: security
+        color: "d93f0b"
+        description: Security hardening or vulnerability fix
+      - name: performance
+        color: "c5def5"
+        description: Performance improvement or optimisation
+      # --- workflow / external state ---
+      - name: blocked
+        color: "b60205"
+        description: An issue that is blocked by external circumstances
+      - name: dependencies
+        color: "0366d6"
+        description: Dependency updates (Dependabot / Renovate)
+      # --- standard GitHub triage helpers (kept org-wide for consistency) ---
+      - name: duplicate
+        color: "cfd3d7"
+        description: This issue or pull request already exists
+      - name: good first issue
+        color: "7057ff"
+        description: Good for newcomers
+      - name: help wanted
+        color: "008672"
+        description: Extra attention is needed
+      - name: question
+        color: "d876e3"
+        description: Further information is requested
+      - name: invalid
+        color: "e4e669"
+        description: This doesn't seem right
+      - name: wontfix
+        color: "ffffff"
+        description: This will not be worked on
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/labels/dotnet-template.yaml
+++ b/deploy/labels/dotnet-template.yaml
@@ -1,14 +1,14 @@
-# Issue labels for devantler-tech/.github. The canonical org taxonomy (22 labels)
+# Issue labels for devantler-tech/dotnet-template. The canonical org taxonomy (22 labels)
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only .github's repo-specific extras (the dependency/ecosystem labels
+# file adds only dotnet-template's repo-specific extras (the dependency/ecosystem labels
 # Dependabot/Renovate apply), declared so the authoritative set doesn't churn
 # against the bots. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
-  name: dot-github
+  name: dotnet-template
   annotations:
-    crossplane.io/external-name: .github
+    crossplane.io/external-name: dotnet-template
 spec:
   managementPolicies:
     - Observe
@@ -16,9 +16,12 @@ spec:
     - Update
     - LateInitialize
   forProvider:
-    repository: .github
-    # No repo-specific extras; the shared patch supplies the full canonical set.
-    label: []
+    repository: dotnet-template
+    label:
+      - name: "dependencies"
+        color: "0366d6"
+      - name: "github_actions"
+        color: "000000"
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/labels/fleet-gitops.yaml
+++ b/deploy/labels/fleet-gitops.yaml
@@ -1,14 +1,14 @@
-# Issue labels for devantler-tech/.github. The canonical org taxonomy (22 labels)
+# Issue labels for devantler-tech/fleet-gitops. The canonical org taxonomy (22 labels)
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only .github's repo-specific extras (the dependency/ecosystem labels
+# file adds only fleet-gitops's repo-specific extras (the dependency/ecosystem labels
 # Dependabot/Renovate apply), declared so the authoritative set doesn't churn
 # against the bots. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
-  name: dot-github
+  name: fleet-gitops
   annotations:
-    crossplane.io/external-name: .github
+    crossplane.io/external-name: fleet-gitops
 spec:
   managementPolicies:
     - Observe
@@ -16,7 +16,7 @@ spec:
     - Update
     - LateInitialize
   forProvider:
-    repository: .github
+    repository: fleet-gitops
     # No repo-specific extras; the shared patch supplies the full canonical set.
     label: []
   providerConfigRef:

--- a/deploy/labels/gitops-tenant-template.yaml
+++ b/deploy/labels/gitops-tenant-template.yaml
@@ -1,14 +1,14 @@
-# Issue labels for devantler-tech/.github. The canonical org taxonomy (22 labels)
+# Issue labels for devantler-tech/gitops-tenant-template. The canonical org taxonomy (22 labels)
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only .github's repo-specific extras (the dependency/ecosystem labels
+# file adds only gitops-tenant-template's repo-specific extras (the dependency/ecosystem labels
 # Dependabot/Renovate apply), declared so the authoritative set doesn't churn
 # against the bots. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
-  name: dot-github
+  name: gitops-tenant-template
   annotations:
-    crossplane.io/external-name: .github
+    crossplane.io/external-name: gitops-tenant-template
 spec:
   managementPolicies:
     - Observe
@@ -16,9 +16,12 @@ spec:
     - Update
     - LateInitialize
   forProvider:
-    repository: .github
-    # No repo-specific extras; the shared patch supplies the full canonical set.
-    label: []
+    repository: gitops-tenant-template
+    label:
+      - name: "dependencies"
+        color: "0366d6"
+      - name: "github_actions"
+        color: "000000"
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/labels/go-template.yaml
+++ b/deploy/labels/go-template.yaml
@@ -1,14 +1,14 @@
-# Issue labels for devantler-tech/.github. The canonical org taxonomy (22 labels)
+# Issue labels for devantler-tech/go-template. The canonical org taxonomy (22 labels)
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only .github's repo-specific extras (the dependency/ecosystem labels
+# file adds only go-template's repo-specific extras (the dependency/ecosystem labels
 # Dependabot/Renovate apply), declared so the authoritative set doesn't churn
 # against the bots. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
-  name: dot-github
+  name: go-template
   annotations:
-    crossplane.io/external-name: .github
+    crossplane.io/external-name: go-template
 spec:
   managementPolicies:
     - Observe
@@ -16,9 +16,12 @@ spec:
     - Update
     - LateInitialize
   forProvider:
-    repository: .github
-    # No repo-specific extras; the shared patch supplies the full canonical set.
-    label: []
+    repository: go-template
+    label:
+      - name: "dependencies"
+        color: "0366d6"
+      - name: "github_actions"
+        color: "000000"
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/labels/homebrew-tap.yaml
+++ b/deploy/labels/homebrew-tap.yaml
@@ -1,14 +1,14 @@
-# Issue labels for devantler-tech/.github. The canonical org taxonomy (22 labels)
+# Issue labels for devantler-tech/homebrew-tap. The canonical org taxonomy (22 labels)
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only .github's repo-specific extras (the dependency/ecosystem labels
+# file adds only homebrew-tap's repo-specific extras (the dependency/ecosystem labels
 # Dependabot/Renovate apply), declared so the authoritative set doesn't churn
 # against the bots. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
-  name: dot-github
+  name: homebrew-tap
   annotations:
-    crossplane.io/external-name: .github
+    crossplane.io/external-name: homebrew-tap
 spec:
   managementPolicies:
     - Observe
@@ -16,9 +16,12 @@ spec:
     - Update
     - LateInitialize
   forProvider:
-    repository: .github
-    # No repo-specific extras; the shared patch supplies the full canonical set.
-    label: []
+    repository: homebrew-tap
+    label:
+      - name: "dependencies"
+        color: "0366d6"
+      - name: "github_actions"
+        color: "000000"
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/labels/ksail.yaml
+++ b/deploy/labels/ksail.yaml
@@ -1,0 +1,35 @@
+# Issue labels for devantler-tech/ksail. The canonical org taxonomy (22 labels)
+# is appended to every IssueLabels by the shared patch in kustomization.yaml; this
+# file adds only ksail's repo-specific extras (the dependency/ecosystem labels
+# Dependabot/Renovate apply), declared so the authoritative set doesn't churn
+# against the bots. See ../README.md.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: IssueLabels
+metadata:
+  name: ksail
+  annotations:
+    crossplane.io/external-name: ksail
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: ksail
+    label:
+      - name: "dependencies"
+        color: "0366d6"
+      - name: "docker"
+        color: "21ceff"
+      - name: "github_actions"
+        color: "000000"
+      - name: "go"
+        color: "16e2e2"
+      - name: "helm"
+        color: "E5F2FC"
+      - name: "javascript"
+        color: "168700"
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/labels/kustomization.yaml
+++ b/deploy/labels/kustomization.yaml
@@ -1,10 +1,113 @@
-# One file per managed repository's issue-label set. `IssueLabels` is the
-# AUTHORITATIVE label manager (the full set is declared per repo and drift is
-# reverted). Extend by adding `<repo>.yaml` — after enumerating that repo's
-# existing labels so the authoritative set doesn't strip one that's in use
-# (notably the `dependencies`/ecosystem labels Dependabot/Renovate apply). See
-# ../README.md and the platform repo's docs/github-management.md.
+# Declarative issue-label management for the devantler-tech org — the Crossplane
+# replacement for the old EndBug/label-sync mechanism (the `sync-github-labels`
+# action + the daily `.sync-labels.yaml` template-synced workflow + the central
+# `actions/.github/labels.yaml` config). `IssueLabels` (provider-upjet-github,
+# terraform github_issue_labels) is authoritative — it manages each repo's COMPLETE
+# label set and reverts drift — exactly like the old action's `delete-other-labels:
+# true`, so the cutover is behaviour-preserving.
+#
+# One file per managed repo declares only that repo's repo-specific EXTRAS (the
+# Dependabot/Renovate ecosystem labels — `dependencies`, `go`, `docker`, … —
+# declared so the authoritative set doesn't churn against the bots that recreate
+# them). The shared patch below appends the CANONICAL org taxonomy (the 22 labels
+# previously in `actions/.github/labels.yaml`) to every IssueLabels — this patch is
+# now the single source of truth for that taxonomy. Mirrors the org-wide settings
+# patch in ../repositories/kustomization.yaml.
+#
+# Scope = the repos managed in ../repositories/ + this repo (.github). Bring a new
+# repo under management by adding `<repo>.yaml` with its live extras (enumerate
+# them first so the authoritative set doesn't strip a label in use).
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - dot-github.yaml
+  - platform.yaml
+  - ksail.yaml
+  - maintenance.yaml
+  - agent-skills.yaml
+  - agent-plugins.yaml
+  - unifi.yaml
+  - gitops-tenant-template.yaml
+  - platform-template.yaml
+  - go-template.yaml
+  - dotnet-template.yaml
+  - homebrew-tap.yaml
+  # Private repos.
+  - ascoachingogvaner.yaml
+  - wedding-app.yaml
+  - fleet-gitops.yaml
+# Canonical org-wide label taxonomy, appended to EVERY IssueLabels (single source
+# of truth — was actions/.github/labels.yaml). Verbatim names + colours from that
+# file so the switch from label-sync to Crossplane changes no labels.
+patches:
+  - target:
+      group: repo.github.m.upbound.io
+      version: v1alpha1
+      kind: IssueLabels
+    patch: |-
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: blocked, color: "d93f0b"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: released, color: "ededed"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: next, color: "5d3fd3"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: roadmap, color: "0e8a16"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: bug, color: "d73a4a"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: enhancement, color: "a2eeef"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: help wanted, color: "008672"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: good first issue, color: "7057ff"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: documentation, color: "0075ca"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: question, color: "d876e3"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: duplicate, color: "cfd3d7"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: wontfix, color: "ffffff"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: spam, color: "e4e669"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: off topic, color: "e4e669"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: needs triage, color: "fbca04"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: needs investigation, color: "fbca04"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: breaking change, color: "b60205"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: performance, color: "f9d0c4"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: security, color: "b60205"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: refactor, color: "c5def5"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: automation, color: "bfdadc"}
+      - op: add
+        path: /spec/forProvider/label/-
+        value: {name: repo-assist, color: "bfdadc"}

--- a/deploy/labels/kustomization.yaml
+++ b/deploy/labels/kustomization.yaml
@@ -1,0 +1,10 @@
+# One file per managed repository's issue-label set. `IssueLabels` is the
+# AUTHORITATIVE label manager (the full set is declared per repo and drift is
+# reverted). Extend by adding `<repo>.yaml` — after enumerating that repo's
+# existing labels so the authoritative set doesn't strip one that's in use
+# (notably the `dependencies`/ecosystem labels Dependabot/Renovate apply). See
+# ../README.md and the platform repo's docs/github-management.md.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dot-github.yaml

--- a/deploy/labels/maintenance.yaml
+++ b/deploy/labels/maintenance.yaml
@@ -1,14 +1,14 @@
-# Issue labels for devantler-tech/.github. The canonical org taxonomy (22 labels)
+# Issue labels for devantler-tech/maintenance. The canonical org taxonomy (22 labels)
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only .github's repo-specific extras (the dependency/ecosystem labels
+# file adds only maintenance's repo-specific extras (the dependency/ecosystem labels
 # Dependabot/Renovate apply), declared so the authoritative set doesn't churn
 # against the bots. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
-  name: dot-github
+  name: maintenance
   annotations:
-    crossplane.io/external-name: .github
+    crossplane.io/external-name: maintenance
 spec:
   managementPolicies:
     - Observe
@@ -16,9 +16,14 @@ spec:
     - Update
     - LateInitialize
   forProvider:
-    repository: .github
-    # No repo-specific extras; the shared patch supplies the full canonical set.
-    label: []
+    repository: maintenance
+    label:
+      - name: "dependencies"
+        color: "0366d6"
+      - name: "github_actions"
+        color: "000000"
+      - name: "javascript"
+        color: "168700"
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/labels/platform-template.yaml
+++ b/deploy/labels/platform-template.yaml
@@ -1,14 +1,14 @@
-# Issue labels for devantler-tech/.github. The canonical org taxonomy (22 labels)
+# Issue labels for devantler-tech/platform-template. The canonical org taxonomy (22 labels)
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only .github's repo-specific extras (the dependency/ecosystem labels
+# file adds only platform-template's repo-specific extras (the dependency/ecosystem labels
 # Dependabot/Renovate apply), declared so the authoritative set doesn't churn
 # against the bots. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
-  name: dot-github
+  name: platform-template
   annotations:
-    crossplane.io/external-name: .github
+    crossplane.io/external-name: platform-template
 spec:
   managementPolicies:
     - Observe
@@ -16,9 +16,12 @@ spec:
     - Update
     - LateInitialize
   forProvider:
-    repository: .github
-    # No repo-specific extras; the shared patch supplies the full canonical set.
-    label: []
+    repository: platform-template
+    label:
+      - name: "dependencies"
+        color: "0366d6"
+      - name: "github_actions"
+        color: "000000"
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/labels/platform.yaml
+++ b/deploy/labels/platform.yaml
@@ -1,0 +1,33 @@
+# Issue labels for devantler-tech/platform. The canonical org taxonomy (22 labels)
+# is appended to every IssueLabels by the shared patch in kustomization.yaml; this
+# file adds only platform's repo-specific extras (the dependency/ecosystem labels
+# Dependabot/Renovate apply), declared so the authoritative set doesn't churn
+# against the bots. See ../README.md.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: IssueLabels
+metadata:
+  name: platform
+  annotations:
+    crossplane.io/external-name: platform
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: platform
+    label:
+      - name: "dependencies"
+        color: "ededed"
+      - name: "github_actions"
+        color: "000000"
+      - name: "kubernetes"
+        color: "ededed"
+      - name: "talos"
+        color: "ededed"
+      - name: "security/review-required"
+        color: "ededed"
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/labels/unifi.yaml
+++ b/deploy/labels/unifi.yaml
@@ -1,14 +1,14 @@
-# Issue labels for devantler-tech/.github. The canonical org taxonomy (22 labels)
+# Issue labels for devantler-tech/unifi. The canonical org taxonomy (22 labels)
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only .github's repo-specific extras (the dependency/ecosystem labels
+# file adds only unifi's repo-specific extras (the dependency/ecosystem labels
 # Dependabot/Renovate apply), declared so the authoritative set doesn't churn
 # against the bots. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
-  name: dot-github
+  name: unifi
   annotations:
-    crossplane.io/external-name: .github
+    crossplane.io/external-name: unifi
 spec:
   managementPolicies:
     - Observe
@@ -16,7 +16,7 @@ spec:
     - Update
     - LateInitialize
   forProvider:
-    repository: .github
+    repository: unifi
     # No repo-specific extras; the shared patch supplies the full canonical set.
     label: []
   providerConfigRef:

--- a/deploy/labels/wedding-app.yaml
+++ b/deploy/labels/wedding-app.yaml
@@ -1,0 +1,31 @@
+# Issue labels for devantler-tech/wedding-app. The canonical org taxonomy (22 labels)
+# is appended to every IssueLabels by the shared patch in kustomization.yaml; this
+# file adds only wedding-app's repo-specific extras (the dependency/ecosystem labels
+# Dependabot/Renovate apply), declared so the authoritative set doesn't churn
+# against the bots. See ../README.md.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: IssueLabels
+metadata:
+  name: wedding-app
+  annotations:
+    crossplane.io/external-name: wedding-app
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: wedding-app
+    label:
+      - name: "dependencies"
+        color: "0366d6"
+      - name: "docker"
+        color: "21ceff"
+      - name: "javascript"
+        color: "168700"
+      - name: "github_actions"
+        color: "000000"
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
`Fixes #51`. This repo is the org's declarative source of truth (`deploy/`, Crossplane + provider-upjet-github), and the maintainer convention is that **all GitHub org/repo/team config — including labels — is managed declaratively, never imperatively** (the `github-config` tenant reverts out-of-band changes). Labels were the last piece still managed the **old way**: the `EndBug/label-sync` action (`devantler-tech/actions/sync-github-labels`, `delete-other-labels: true`) driven by a template-synced daily workflow (`.sync-labels.yaml`) reading a central `actions/.github/labels.yaml`. This PR replaces that mechanism with declarative `IssueLabels` for **every managed repo**, per maintainer direction ("declarative with Crossplane is best; do it for all repos and remove the old approach").

## What this does
Adds an `IssueLabels` (`repo.github.m.upbound.io/v1alpha1`, the authoritative `github_issue_labels` — same prune semantics as the old `delete-other-labels: true`) for each repo in `deploy/repositories/` **+ `.github`** (15 resources), under `deploy/labels/`:

- **Canonical taxonomy centralized once** in `deploy/labels/kustomization.yaml` — a shared patch appends the **22 canonical labels** (verbatim names + colours from `actions/.github/labels.yaml`) to *every* `IssueLabels`. This patch is the new single source of truth for the taxonomy (mirrors the org-wide settings patch in `repositories/kustomization.yaml`).
- **Per-repo files carry only that repo's live extras** — the Dependabot/Renovate ecosystem labels (`dependencies`, `go`, `docker`, `helm`, `javascript`, `github_actions`, and platform's renovate `kubernetes`/`talos`/`security/review-required`), with their **exact current colours** (e.g. dependabot `dependencies=0366d6` vs platform-renovate `ededed`). Declaring them keeps the authoritative resource from churning against the bots that recreate them.

## Behaviour-preserving cutover
Each repo's resulting set = **its exact current live set**, so flipping from label-sync to Crossplane changes no labels. Verified counts match live: ksail 28, platform 27, maintenance 25, … The only intentional deltas:
- **`.github`**: 1 → 22 labels — it was never fully synced (only had `blocked` at the wrong colour `b60205`); now gets the canonical set (`blocked` → `d93f0b`).
- **`fleet-gitops`**: drops a stray GitHub-default `invalid` label (drift the canonical set omits).

## Why no platform change is needed
Verified live: `issuelabels.repo.github.m.upbound.io` is already in the platform `ManagedResourceActivationPolicy`, and the `github-config` tenant `Role` already grants full verbs on the `repo.github.m.upbound.io` apiGroup. Pure `deploy/` addition.

## Removing the old approach — tracked in #58 (Phase 2)
The `EndBug/label-sync` mechanism becomes redundant once this reconciles. Removal is deliberately a **separate, sequenced** step (**after** this merges and is verified live — never leave a gap in label management): delete the `.sync-labels.yaml` template, each repo's synced `sync-labels.yaml`, and the `actions/sync-github-labels` action + `actions/.github/labels.yaml`. Full plan in #58.

## Scope note
`actions` + `reusable-workflows` also run label-sync but are **not** in `deploy/repositories/`, so their labels aren't declared here (provider-App access unconfirmed) — flagged in #58 to resolve before removing *their* sync workflow.

## Validation
`kubectl kustomize deploy/` (CI's `🧹 Validate manifests` step) builds clean; all 15 `IssueLabels` render with the expected `forProvider.{repository,label[]}` shape, correct counts, no duplicate label names.

Part of #56 (declarative GitHub-org-as-code).