### PR TITLE
chore(repositories): declare discoverability metadata on managed Repository CRs

### DIFF
--- a/deploy/repositories/agent-plugins.yaml
+++ b/deploy/repositories/agent-plugins.yaml
@@ -10,7 +10,8 @@ metadata:
     crossplane.io/external-name: agent-plugins
 spec:
   # Squash-only merge policy + webCommitSignoffRequired come from the shared
-  # patch; everything else is adopted via LateInitialize.
+  # patch; description is declared here so the config is AUTHORITATIVE for it
+  # (previously LateInitialized); everything else is adopted via LateInitialize.
   managementPolicies:
     - Observe
     - Create
@@ -18,6 +19,7 @@ spec:
     - LateInitialize
   forProvider:
     name: agent-plugins
+    description: "Industry-standard agent-plugin marketplace — bundles curated skills from devantler-tech/skills into category-based plugins for VS Code, GitHub Copilot CLI, and Claude Code (dual manifests)."
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/agent-skills.yaml
+++ b/deploy/repositories/agent-skills.yaml
@@ -11,7 +11,8 @@ metadata:
     crossplane.io/external-name: agent-skills
 spec:
   # Squash-only merge policy + webCommitSignoffRequired come from the shared
-  # patch; everything else is adopted via LateInitialize.
+  # patch; description is declared here so the config is AUTHORITATIVE for it
+  # (previously LateInitialized); everything else is adopted via LateInitialize.
   managementPolicies:
     - Observe
     - Create
@@ -19,6 +20,7 @@ spec:
     - LateInitialize
   forProvider:
     name: agent-skills
+    description: "Generic Copilot / agent skills, installable via gh skill"
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/ascoachingogvaner.yaml
+++ b/deploy/repositories/ascoachingogvaner.yaml
@@ -6,9 +6,10 @@ metadata:
     crossplane.io/external-name: ascoachingogvaner
 spec:
   # Actively managed (everything except Delete). Merge policy from the shared
-  # patch; LateInitialize adopts every other setting unchanged. PRIVATE repo:
-  # visibility is pinned private explicitly (never left to inference) so
-  # management can never expose it, and archived false so it can't be archived.
+  # patch. PRIVATE repo: visibility is pinned private explicitly (never left to
+  # inference) so management can never expose it, and archived false so it can't
+  # be archived. description is declared so the config is AUTHORITATIVE for it
+  # (previously LateInitialized); LateInitialize adopts every other setting.
   managementPolicies:
     - Observe
     - Create
@@ -18,6 +19,7 @@ spec:
     name: ascoachingogvaner
     visibility: private
     archived: false
+    description: "AS Coaching og Vaner — coaching website (platform tenant)"
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/dotnet-template.yaml
+++ b/deploy/repositories/dotnet-template.yaml
@@ -5,11 +5,11 @@ metadata:
   annotations:
     crossplane.io/external-name: dotnet-template
 spec:
-  # Managed (all except Delete). forProvider is intentionally minimal: only the
-  # required name is set here; the org-wide squash-only merge policy comes from
-  # the shared patch in kustomization.yaml, and every other setting is adopted
-  # unchanged from the live repo via LateInitialize. So the only changes this
-  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  # Managed (all except Delete). forProvider now declares the discoverability
+  # metadata (description/topics) so the config is AUTHORITATIVE for it
+  # (previously LateInitialized from live); the org-wide squash-only merge policy
+  # still comes from the shared patch in kustomization.yaml, and every other
+  # setting is still adopted unchanged from the live repo via LateInitialize.
   managementPolicies:
     - Observe
     - Create
@@ -17,6 +17,8 @@ spec:
     - LateInitialize
   forProvider:
     name: dotnet-template
+    description: "A simple .NET template for new projects."
+    topics: ["template"]
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/fleet-gitops.yaml
+++ b/deploy/repositories/fleet-gitops.yaml
@@ -6,9 +6,10 @@ metadata:
     crossplane.io/external-name: fleet-gitops
 spec:
   # Actively managed (everything except Delete). Merge policy from the shared
-  # patch; LateInitialize adopts every other setting unchanged. PRIVATE repo:
-  # visibility is pinned private explicitly (never left to inference) so
-  # management can never expose it, and archived false so it can't be archived.
+  # patch. PRIVATE repo: visibility is pinned private explicitly (never left to
+  # inference) so management can never expose it, and archived false so it can't
+  # be archived. description is declared so the config is AUTHORITATIVE for it
+  # (previously LateInitialized); LateInitialize adopts every other setting.
   managementPolicies:
     - Observe
     - Create
@@ -18,6 +19,7 @@ spec:
     name: fleet-gitops
     visibility: private
     archived: false
+    description: "FleetDM GitOps configuration for devantler-tech device management."
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/gitops-tenant-template.yaml
+++ b/deploy/repositories/gitops-tenant-template.yaml
@@ -5,11 +5,11 @@ metadata:
   annotations:
     crossplane.io/external-name: gitops-tenant-template
 spec:
-  # Managed (all except Delete). forProvider is intentionally minimal: only the
-  # required name is set here; the org-wide squash-only merge policy comes from
-  # the shared patch in kustomization.yaml, and every other setting is adopted
-  # unchanged from the live repo via LateInitialize. So the only changes this
-  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  # Managed (all except Delete). forProvider now declares the discoverability
+  # metadata (description/topics) so the config is AUTHORITATIVE for it
+  # (previously LateInitialized from live); the org-wide squash-only merge policy
+  # still comes from the shared patch in kustomization.yaml, and every other
+  # setting is still adopted unchanged from the live repo via LateInitialize.
   managementPolicies:
     - Observe
     - Create
@@ -17,6 +17,7 @@ spec:
     - LateInitialize
   forProvider:
     name: gitops-tenant-template
+    description: "Template for GitOps tenants on the devantler-tech platform — framework-agnostic CI/CD plumbing kept current via template-sync."
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/go-template.yaml
+++ b/deploy/repositories/go-template.yaml
@@ -5,11 +5,11 @@ metadata:
   annotations:
     crossplane.io/external-name: go-template
 spec:
-  # Managed (all except Delete). forProvider is intentionally minimal: only the
-  # required name is set here; the org-wide squash-only merge policy comes from
-  # the shared patch in kustomization.yaml, and every other setting is adopted
-  # unchanged from the live repo via LateInitialize. So the only changes this
-  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  # Managed (all except Delete). forProvider now declares the discoverability
+  # metadata (description/topics) so the config is AUTHORITATIVE for it
+  # (previously LateInitialized from live); the org-wide squash-only merge policy
+  # still comes from the shared patch in kustomization.yaml, and every other
+  # setting is still adopted unchanged from the live repo via LateInitialize.
   managementPolicies:
     - Observe
     - Create
@@ -17,6 +17,8 @@ spec:
     - LateInitialize
   forProvider:
     name: go-template
+    description: "A simple Go template for new projects."
+    topics: ["template"]
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/homebrew-tap.yaml
+++ b/deploy/repositories/homebrew-tap.yaml
@@ -5,11 +5,12 @@ metadata:
   annotations:
     crossplane.io/external-name: homebrew-tap
 spec:
-  # Managed (all except Delete). forProvider is intentionally minimal: only the
-  # required name is set here; the org-wide squash-only merge policy comes from
-  # the shared patch in kustomization.yaml, and every other setting is adopted
-  # unchanged from the live repo via LateInitialize. So the only changes this
-  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  # Managed (all except Delete). forProvider now declares the discoverability
+  # metadata so the config is AUTHORITATIVE for it; the org-wide squash-only
+  # merge policy still comes from the shared patch in kustomization.yaml, and
+  # every other setting is still adopted unchanged via LateInitialize.
+  # NB: this is the one repo whose live description was empty — declaring it here
+  # is a real (intentional) Update, not a no-op cutover like the other repos.
   managementPolicies:
     - Observe
     - Create
@@ -17,6 +18,8 @@ spec:
     - LateInitialize
   forProvider:
     name: homebrew-tap
+    description: "Homebrew tap for devantler-tech CLIs (e.g. ksail)."
+    topics: ["marketplace"]
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/ksail.yaml
+++ b/deploy/repositories/ksail.yaml
@@ -8,8 +8,10 @@ metadata:
     crossplane.io/external-name: ksail
 spec:
   # Actively managed (everything except Delete). Merge policy from the shared
-  # patch; LateInitialize adopts the rest. visibility pinned public + archived
-  # false so management can never flip visibility or archive this repo.
+  # patch; visibility pinned public + archived false so management can never
+  # flip visibility or archive this repo. Discoverability metadata
+  # (description/topics/homepageUrl) is declared so the config is AUTHORITATIVE
+  # for it (previously LateInitialized from live); LateInitialize adopts the rest.
   managementPolicies:
     - Observe
     - Create
@@ -19,6 +21,9 @@ spec:
     name: ksail
     visibility: public
     archived: false
+    description: "All-in-one Kubernetes SDK: create, manage, and operate clusters across distributions (Kind, K3d, Talos, VCluster) with built-in GitOps, secrets, AI assistant, and MCP server. Only requires Docker or a Cloud Provider."
+    homepageUrl: "https://ksail.devantler.tech/"
+    topics: ["argocd", "chat", "cli", "cloud-native", "developer-tool", "devops", "docker", "flux", "github-copilot", "gitops", "helm", "k3s", "kind", "kubernetes", "local-development", "mcp-server", "provisioner", "talos", "tui", "vcluster"]
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/platform-template.yaml
+++ b/deploy/repositories/platform-template.yaml
@@ -5,11 +5,11 @@ metadata:
   annotations:
     crossplane.io/external-name: platform-template
 spec:
-  # Managed (all except Delete). forProvider is intentionally minimal: only the
-  # required name is set here; the org-wide squash-only merge policy comes from
-  # the shared patch in kustomization.yaml, and every other setting is adopted
-  # unchanged from the live repo via LateInitialize. So the only changes this
-  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  # Managed (all except Delete). forProvider now declares the discoverability
+  # metadata (description/topics) so the config is AUTHORITATIVE for it
+  # (previously LateInitialized from live); the org-wide squash-only merge policy
+  # still comes from the shared patch in kustomization.yaml, and every other
+  # setting is still adopted unchanged from the live repo via LateInitialize.
   managementPolicies:
     - Observe
     - Create
@@ -17,6 +17,8 @@ spec:
     - LateInitialize
   forProvider:
     name: platform-template
+    description: "Opinionated, batteries-included Kubernetes platform (Flux GitOps + KSail + Talos) you instantiate from a template — fully automated bootstrap from GitHub Secrets. Derived from devantler-tech/platform."
+    topics: ["flux", "gitops", "hetzner", "ksail", "kubernetes", "platform", "talos", "template"]
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/platform.yaml
+++ b/deploy/repositories/platform.yaml
@@ -8,9 +8,11 @@ metadata:
     crossplane.io/external-name: platform
 spec:
   # Actively managed (everything except Delete). The merge policy comes from the
-  # shared patch in kustomization.yaml; LateInitialize adopts every other setting
-  # unchanged. visibility is pinned public and archived false explicitly so
-  # management can never flip visibility or archive this repo.
+  # shared patch in kustomization.yaml; visibility is pinned public and archived
+  # false explicitly so management can never flip visibility or archive this
+  # repo. Discoverability metadata (description/topics/homepageUrl) is declared
+  # so the config is AUTHORITATIVE for it (previously LateInitialized from live);
+  # LateInitialize adopts every other setting unchanged.
   managementPolicies:
     - Observe
     - Create
@@ -20,6 +22,9 @@ spec:
     name: platform
     visibility: public
     archived: false
+    description: "DevantlerTech Platform - including deployment artifacts for running the platform in CI/CD and in Talos Omni."
+    homepageUrl: "http://platform.devantler.tech/"
+    topics: ["infrastructure"]
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/unifi.yaml
+++ b/deploy/repositories/unifi.yaml
@@ -5,11 +5,11 @@ metadata:
   annotations:
     crossplane.io/external-name: unifi
 spec:
-  # Managed (all except Delete). forProvider is intentionally minimal: only the
-  # required name is set here; the org-wide squash-only merge policy comes from
-  # the shared patch in kustomization.yaml, and every other setting is adopted
-  # unchanged from the live repo via LateInitialize. So the only changes this
-  # makes are the merge-policy fields (+ a cosmetic homepage null->"").
+  # Managed (all except Delete). forProvider now declares the discoverability
+  # metadata (description/topics) so the config is AUTHORITATIVE for it
+  # (previously LateInitialized from live); the org-wide squash-only merge policy
+  # still comes from the shared patch in kustomization.yaml, and every other
+  # setting is still adopted unchanged from the live repo via LateInitialize.
   managementPolicies:
     - Observe
     - Create
@@ -17,6 +17,8 @@ spec:
     - LateInitialize
   forProvider:
     name: unifi
+    description: "Declarative configuration of my UniFi network (OpenTofu + filipowm/unifi), reconciled by tofu-controller as a platform tenant"
+    topics: ["flux", "gitops", "iac", "opentofu", "terraform", "tofu-controller", "ubiquiti", "unifi"]
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/wedding-app.yaml
+++ b/deploy/repositories/wedding-app.yaml
@@ -6,9 +6,10 @@ metadata:
     crossplane.io/external-name: wedding-app
 spec:
   # Actively managed (everything except Delete). Merge policy from the shared
-  # patch; LateInitialize adopts every other setting unchanged. PRIVATE repo:
-  # visibility is pinned private explicitly (never left to inference) so
-  # management can never expose it, and archived false so it can't be archived.
+  # patch. PRIVATE repo: visibility is pinned private explicitly (never left to
+  # inference) so management can never expose it, and archived false so it can't
+  # be archived. description is declared so the config is AUTHORITATIVE for it
+  # (previously LateInitialized); LateInitialize adopts every other setting.
   managementPolicies:
     - Observe
     - Create
@@ -18,6 +19,7 @@ spec:
     name: wedding-app
     visibility: private
     archived: false
+    description: "A simple wedding API service deployed to the devantler-tech/platform Kubernetes cluster."
   providerConfigRef:
     kind: ProviderConfig
     name: default


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What
Populate `description`, `topics`, and `homepageUrl` on the managed `Repository` CRs in `deploy/repositories/` so the declarative config is **authoritative** for repo discoverability metadata, instead of leaving it implicitly LateInitialized from live GitHub state.

`Fixes #54.`

## Why
Before this PR only `maintenance.yaml` set `forProvider.description`; every other `Repository` CR set just `name` (+ `visibility`/`archived` on a few). Description/topics/homepage therefore lived only in GitHub's UI state, adopted via `LateInitialize` — so the declarative config under-specified real desired state and any out-of-band drift (e.g. a topic edited in the UI) would never be reconciled. For a public org whose repos are its products, that also leaves discoverability unmanaged.

## How — Observe-safe, additive
- Each CR now declares its **current live** `description` (and `topics`/`homepageUrl` **where live has a non-empty value**), sourced verbatim from the live repo metadata. Because the values equal what `LateInitialize` already adopted, the cutover is a **no-op against live state** — it just moves the source of truth into Git.
- Fields that are empty live (most repos' `homepageUrl`, several repos' `topics`) are **omitted**, not declared empty — keeping the change purely additive and avoiding authoritative-empty churn. They can be enriched in a focused follow-up.
- Confirmed field names against the authoritative provider CRD (`crossplane-contrib/provider-upjet-github` → `repo.github.m.upbound.io_repositories.yaml`): `description`, `topics` (list), `homepageUrl` (not `homepage`).

### The one deliberate live change
- **`homebrew-tap`**: its live `description` was empty (`null`) — this is the only repo where declaring the field is a real `Update`, not a no-op. Set to `"Homebrew tap for devantler-tech CLIs (e.g. ksail)."` (flagged in an inline comment too). All other repos are no-op cutovers.

## Coverage
13 CRs updated (every managed repo except `maintenance`, which already declared its description and has no live topics/homepage):

| | description | topics | homepageUrl |
|---|---|---|---|
| ksail, platform | ✅ | ✅ | ✅ |
| dotnet-template, go-template, homebrew-tap, platform-template, unifi | ✅ | ✅ | — (empty live) |
| agent-plugins, agent-skills, ascoachingogvaner, fleet-gitops, gitops-tenant-template, wedding-app | ✅ | — (empty live) | — (empty live) |

Also refreshed the per-file comments that previously claimed `forProvider` was "intentionally minimal: only the required name is set" — that's no longer true, so the comments now describe the declared metadata (config-file freshness).

## Validation
- `kubectl kustomize deploy/` builds clean — 42 resources; all 14 `Repository` resources carry `description`, with `topics`/`homepageUrl` present exactly where intended (verified per-resource).
- Values mirror live `gh api repos/devantler-tech/<repo>` output, so reconciliation is a no-op everywhere except the homebrew-tap description noted above.

## Roadmap
Advances epic #56 (declarative GitHub-org-as-code — extend coverage & sustain the source of truth).
