### PR TITLE
ci: cut releases automatically so merged deploy/ state reaches the cluster

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,18 @@
+name: Release
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@c830916321473ec23bb612e41de963b9b01af897 # v5.6.6
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,8 @@
+{
+  "branches": [
+    "main"
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer"
+  ]
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem — merged `deploy/` state never reaches the cluster

The `github-config` tenant on the platform cluster syncs the org's declarative GitHub state from a cosign-signed **OCI artifact** (`oci://ghcr.io/devantler-tech/github-config/manifests`, `semver: ">=1.0.0"`). That artifact is published by **`cd.yaml`, which runs only on `push: tags: v*`**. `ci.yaml` only validates PRs; nothing in the repo cuts a `v*` tag on merge to `main`.

The last tags (v1.4.0–v1.4.2, 2026-06-18) were **hand-cut** by the maintainer during the initial rollout. Since then three `deploy/` PRs merged but **no tag was cut**, so none of them are live:

| Merged | PR | Desired state | Live on cluster? |
|---|---|---|---|
| 06-19 | #50 `feat(deploy):` | `maintainers` team + 12 `TeamRepository` bindings | ❌ `Team`/`TeamRepository` → `No resources found` |
| 06-21 | #57 `feat(deploy):` | `IssueLabels` across all repos | ❌ `IssueLabels` → `No resources found` |
| 06-22 | #60 `chore(repositories):` | repository discoverability metadata | ❌ (still 1.4.2) |

Live evidence: the `github-config` `OCIRepository` is still on `1.4.2@sha256:293cbda…`; `Repository` CRs are all `True/True` (provider healthy) but `kubectl get teams,teamrepositories,issuelabels -A` returns nothing. So the declarative-GitHub GitOps path is broken end-to-end **after merge** — exactly the "manage GitHub declaratively" guarantee #57/#50 were meant to deliver.

## Fix — the standard release pipeline every other repo already has

Add a `Release` workflow that runs the shared `create-release.yaml` (semantic-release) on push to `main`, plus a minimal `.releaserc` (`@semantic-release/commit-analyzer` only). semantic-release cuts the `v*` tag → `cd.yaml` publishes the OCI artifact → the tenant reconciles. This is **byte-identical in structure to `go-template`'s `release.yaml` + `.releaserc`** (the canonical template; its releases are auto-cut by `github-actions[bot]`), differing only in the pinned reusable-workflow SHA (latest `v5.6.6`).

## ⚠️ Blast radius of the first auto-release

Once this merges, the first run analyzes commits since `v1.4.2` — which include #50 and #57 (`feat:`) — so it cuts **v1.5.0** and delivers the whole backlog at once. That includes #57's `IssueLabels`, which are **authoritative** (they remove any labels not in the declarative set). That is the intended behavior of #57, surfaced here so the first reconcile is no surprise.

## Design question for the promoter

If `.github` releases were intentionally kept **manual** to gate when sensitive org-state reconciles, close this. The evidence (3 PRs / 5 days of silent, unintended drift; every other repo auto-releases; no documented manual-gating intent) says this is a gap, not a design choice — but the promotion is your call.

## Validation
- `kubectl kustomize deploy/` — OK (unchanged; this PR adds no manifests).
- `release.yaml` YAML valid; structurally identical to `go-template`'s working workflow.
- `.releaserc` valid JSON, mirrors `go-template`.
- Root cause confirmed against live cluster + the OCIRepository revision + release/run history.
