### PR TITLE
fix(teams): reference maintainers team by numerical id so #50 reconciles

### DIFF
--- a/deploy/teams/maintainers.yaml
+++ b/deploy/teams/maintainers.yaml
@@ -9,8 +9,11 @@ kind: Team
 metadata:
   name: maintainers
   annotations:
-    # Adopt the EXISTING devantler-tech/maintainers team (read-only).
-    crossplane.io/external-name: maintainers
+    # Adopt the EXISTING devantler-tech/maintainers team (read-only). provider-github
+    # imports a Team by its NUMERICAL id, not its slug — a slug external-name fails
+    # observe with `Unexpected ID format ("maintainers"), expected numerical ID`. The
+    # team id is stable; `forProvider.name` keeps the slug as the human-readable name.
+    crossplane.io/external-name: "17046606"
 spec:
   managementPolicies: ["Observe"]
   forProvider:
@@ -28,7 +31,8 @@ metadata:
 spec:
   managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
   forProvider:
-    teamId: maintainers
+    teamIdRef:
+      name: maintainers
     username: devantler
     role: maintainer
   providerConfigRef:
@@ -40,11 +44,12 @@ kind: TeamRepository
 metadata:
   name: maintainers-actions
   annotations:
-    crossplane.io/external-name: maintainers:actions
+    crossplane.io/external-name: "17046606:actions"
 spec:
   managementPolicies: ["Observe"]
   forProvider:
-    teamId: maintainers
+    teamIdRef:
+      name: maintainers
     repository: actions
     permission: maintain
   providerConfigRef:
@@ -56,11 +61,12 @@ kind: TeamRepository
 metadata:
   name: maintainers-dotnet-template
   annotations:
-    crossplane.io/external-name: maintainers:dotnet-template
+    crossplane.io/external-name: "17046606:dotnet-template"
 spec:
   managementPolicies: ["Observe"]
   forProvider:
-    teamId: maintainers
+    teamIdRef:
+      name: maintainers
     repository: dotnet-template
     permission: maintain
   providerConfigRef:
@@ -72,11 +78,12 @@ kind: TeamRepository
 metadata:
   name: maintainers-go-template
   annotations:
-    crossplane.io/external-name: maintainers:go-template
+    crossplane.io/external-name: "17046606:go-template"
 spec:
   managementPolicies: ["Observe"]
   forProvider:
-    teamId: maintainers
+    teamIdRef:
+      name: maintainers
     repository: go-template
     permission: maintain
   providerConfigRef:
@@ -88,11 +95,12 @@ kind: TeamRepository
 metadata:
   name: maintainers-ksail
   annotations:
-    crossplane.io/external-name: maintainers:ksail
+    crossplane.io/external-name: "17046606:ksail"
 spec:
   managementPolicies: ["Observe"]
   forProvider:
-    teamId: maintainers
+    teamIdRef:
+      name: maintainers
     repository: ksail
     permission: maintain
   providerConfigRef:
@@ -104,11 +112,12 @@ kind: TeamRepository
 metadata:
   name: maintainers-monorepo
   annotations:
-    crossplane.io/external-name: maintainers:monorepo
+    crossplane.io/external-name: "17046606:monorepo"
 spec:
   managementPolicies: ["Observe"]
   forProvider:
-    teamId: maintainers
+    teamIdRef:
+      name: maintainers
     repository: monorepo
     permission: maintain
   providerConfigRef:
@@ -120,11 +129,12 @@ kind: TeamRepository
 metadata:
   name: maintainers-platform
   annotations:
-    crossplane.io/external-name: maintainers:platform
+    crossplane.io/external-name: "17046606:platform"
 spec:
   managementPolicies: ["Observe"]
   forProvider:
-    teamId: maintainers
+    teamIdRef:
+      name: maintainers
     repository: platform
     permission: maintain
   providerConfigRef:
@@ -136,11 +146,12 @@ kind: TeamRepository
 metadata:
   name: maintainers-reusable-workflows
   annotations:
-    crossplane.io/external-name: maintainers:reusable-workflows
+    crossplane.io/external-name: "17046606:reusable-workflows"
 spec:
   managementPolicies: ["Observe"]
   forProvider:
-    teamId: maintainers
+    teamIdRef:
+      name: maintainers
     repository: reusable-workflows
     permission: maintain
   providerConfigRef:
@@ -154,7 +165,8 @@ metadata:
 spec:
   managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
   forProvider:
-    teamId: maintainers
+    teamIdRef:
+      name: maintainers
     repository: gitops-tenant-template
     permission: maintain
   providerConfigRef:
@@ -168,7 +180,8 @@ metadata:
 spec:
   managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
   forProvider:
-    teamId: maintainers
+    teamIdRef:
+      name: maintainers
     repository: platform-template
     permission: maintain
   providerConfigRef:
@@ -182,7 +195,8 @@ metadata:
 spec:
   managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
   forProvider:
-    teamId: maintainers
+    teamIdRef:
+      name: maintainers
     repository: unifi
     permission: maintain
   providerConfigRef:
@@ -196,7 +210,8 @@ metadata:
 spec:
   managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
   forProvider:
-    teamId: maintainers
+    teamIdRef:
+      name: maintainers
     repository: homebrew-tap
     permission: maintain
   providerConfigRef:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem (live delivery break, found this run)

Merging #62 cut **v1.5.0**, which finally delivered the merged `deploy/` backlog to the cluster. The IssueLabels (#57) and repo metadata (#60) reconciled cleanly — **but the entire team taxonomy from #50 is failing to reconcile**:

```
Team/maintainers              Synced=False  ReconcileError: observe failed:
  Unexpected ID format ("maintainers"), expected numerical ID.
  strconv.ParseInt: parsing "maintainers": invalid syntax
TeamRepository/maintainers-*  Synced=False  (x11, same ParseInt error)
TeamMembership/maintainers-devantler  Synced=False
```

`provider-github` (upjet/terraform-provider-github) imports **Team**, **TeamRepository** and **TeamMembership** by the team's **numerical id**, not its slug. #50 referenced the team by the slug `maintainers` everywhere (the Team `external-name`, every `forProvider.teamId`, and the `maintainers:<repo>` TeamRepository import ids), so every observe call fails `ParseInt` and nothing syncs.

## Fix

- **Team** `crossplane.io/external-name`: `maintainers` -> `"17046606"` (the stable numerical id of `devantler-tech/maintainers`; `forProvider.name` keeps the slug as the display name).
- **TeamRepository / TeamMembership**: hardcoded `teamId: maintainers` -> `teamIdRef: { name: maintainers }` so the team id resolves from the Team CR's (now numerical) external-name — DRY and recreate-safe.
- **TeamRepository import ids**: `maintainers:<repo>` -> `"17046606:<repo>"` (the `<team_id>:<repo>` import format).

No membership, permission level, or repo scope changes — all `managementPolicies` are untouched. This only makes the **already-merged, already-decided** #50 declaration functional.

## Validation

- `kubectl kustomize deploy/` (the CI gate) builds — 42 resources; Team renders `external-name: "17046606"`, 12 `teamIdRef`s resolve.
- **CI is schema-only** — it does not run a live provider reconcile, so green CI proves the YAML is valid, not that the team adopts cleanly. The real proof is the live reconcile after merge:

  ```
  kubectl get teams.team.github.m.upbound.io,teamrepositories.team.github.m.upbound.io,teammemberships.team.github.m.upbound.io -n github-config
  ```

  All should flip `SYNCED=True`. (The numerical id `17046606` was read live from `gh api orgs/devantler-tech/teams/maintainers`.)

Once promoted I'll drive it to merge and confirm the reconcile live. Unblocks the #50 work actually taking effect; orthogonal to #53 (team coverage / permission-level, still a maintainer decision).