### PR TITLE
fix(deploy): restore GitHub App credential wiring dropped in #50

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -7,6 +7,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # Tenant-owned auth wiring: the namespaced ProviderConfig + the GitHub App
+  # credential ExternalSecret (read via the platform-provisioned namespaced
+  # SecretStore). These MUST stay in the artifact — without them the credential
+  # Secret is never materialized and the ProviderConfig is pruned, so every
+  # managed resource below fails to connect. See the platform repo's
+  # docs/github-management.md.
+  - external-secret.yaml
+  - provider-config.yaml
   - repositories/
   - teams/
   - labels/


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem — declarative GitHub state stopped reconciling (regression)

Every github-provider managed resource in the `github-config` tenant is currently `Synced=False`:

```
ReconcileError: connect failed: cannot initialize the Terraform plugin SDK async
external client: ... cannot get credentials secret: Secret "github-app-credentials"
not found
```

Verified live (read-only) — **all 14 `Repository` CRs and all 15 `IssueLabels` CRs** carry this error, and the secret `github-app-credentials` exists nowhere in the cluster. So #50 (teams), #57 (labels) and #60 (repo metadata) are **not actually live** — the earlier `Ready=True` readings were sticky from a prior successful reconcile.

## Root cause

`deploy/kustomization.yaml` lost its credential wiring. The history:

| commit | PR | `resources:` |
|---|---|---|
| `fc63c75e` | #41 (own the credential ES + ProviderConfig) | `external-secret.yaml`, `provider-config.yaml`, `repositories/` |
| `8be67942` | **#50 (manage maintainers team)** | `repositories/`, `teams/` ← **ES + PC silently dropped** |
| `8e26a415` | #57 (labels) | `repositories/`, `teams/`, `labels/` |

PR #50 inadvertently removed `external-secret.yaml` and `provider-config.yaml`. The break stayed **latent** because the tenant `OCIRepository` was pinned at `v1.4.2` (which still carried them) until **#62 enabled auto-release and cut `v1.5.0`** this morning. Applying `v1.5.0` (with `prune: true`) then:
- deleted the `ExternalSecret` → `github-app-credentials` disappeared, and
- began terminating the `ProviderConfig/default` (`deletionTimestamp=2026-06-23T06:17:39Z`, blocked on its in-use finalizer).

Live confirmation: `OCIRepository` = `1.5.0`, but the `github-config` Flux Kustomization is stuck `Reconciling/Progressing` (lastApplied still `1.4.2`, health checks timing out) because the pruned-away credential leaves every MR unhealthy.

## Fix

Restore `external-secret.yaml` + `provider-config.yaml` to the resources list (with a guard comment so a future PR doesn't drop them again). `kubectl kustomize deploy/` builds clean — **44 resources** (was 42; the +2 are the restored ExternalSecret + ProviderConfig).

Once this merges → auto-release cuts `v1.5.1` → the artifact re-ships the wiring → the `ExternalSecret` re-materializes `github-app-credentials` from OpenBao (`secret/infrastructure/github/app`, already seeded — it reconciled under v1.4.x) → the provider authenticates → MRs go `Synced=True`.

## ⚠️ Live remediation may still be needed (maintainer, prod write)

The `ProviderConfig/default` is mid-deletion (terminating on its finalizer). A re-published artifact cannot un-delete a terminating object, so the restored `ProviderConfig` may not recreate until the old one finishes deleting. After `v1.5.1` reconciles, verify:

```sh
kubectl --context admin@prod -n github-config get providerconfig.github.m.upbound.io default
kubectl --context admin@prod -n github-config get secret github-app-credentials
kubectl --context admin@prod get repositories.repo.github.m.upbound.io,issuelabels.repo.github.m.upbound.io -A \
  -o custom-columns=NAME:.metadata.name,SYNCED:'.status.conditions[?(@.type=="Synced")].status'
```

If the `ProviderConfig` is still `Terminating` and blocking recreation, clearing its finalizer (or letting Crossplane GC the `ProviderConfigUsage`s once the secret returns) is the one-time unwedge — a prod write left for you.

## Impact / blocks

This is the binding blocker behind the whole declarative-GitHub epic (#56): #50 / #57 / #60 are non-functional until it lands, and #58 (remove the EndBug/label-sync mechanism) **must not** proceed until labels demonstrably reconcile live again.

Part of #56.
