### PR TITLE
feat(deploy): declare labels for actions + reusable-workflows

### DIFF
--- a/deploy/labels/actions.yaml
+++ b/deploy/labels/actions.yaml
@@ -1,0 +1,27 @@
+# Issue labels for devantler-tech/actions. The canonical org taxonomy (22 labels)
+# is appended to every IssueLabels by the shared patch in kustomization.yaml; this
+# file adds only actions's repo-specific extras (the dependency/ecosystem labels
+# Dependabot/Renovate apply), declared so the authoritative set doesn't churn
+# against the bots. See ../README.md.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: IssueLabels
+metadata:
+  name: actions
+  annotations:
+    crossplane.io/external-name: actions
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: actions
+    label:
+      - name: "dependencies"
+        color: "0366d6"
+      - name: "github_actions"
+        color: "000000"
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/labels/kustomization.yaml
+++ b/deploy/labels/kustomization.yaml
@@ -32,6 +32,8 @@ resources:
   - go-template.yaml
   - dotnet-template.yaml
   - homebrew-tap.yaml
+  - actions.yaml
+  - reusable-workflows.yaml
   # Private repos.
   - ascoachingogvaner.yaml
   - wedding-app.yaml

--- a/deploy/labels/reusable-workflows.yaml
+++ b/deploy/labels/reusable-workflows.yaml
@@ -1,0 +1,27 @@
+# Issue labels for devantler-tech/reusable-workflows. The canonical org taxonomy
+# (22 labels) is appended to every IssueLabels by the shared patch in
+# kustomization.yaml; this file adds only reusable-workflows's repo-specific extras
+# (the dependency/ecosystem labels Dependabot/Renovate apply), declared so the
+# authoritative set doesn't churn against the bots. See ../README.md.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: IssueLabels
+metadata:
+  name: reusable-workflows
+  annotations:
+    crossplane.io/external-name: reusable-workflows
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: reusable-workflows
+    label:
+      - name: "dependencies"
+        color: "0366d6"
+      - name: "github_actions"
+        color: "000000"
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
Resolves the **open scope decision** flagged in #57 / #58: `actions` and
`reusable-workflows` were the only repos in the managed suite **without** a
declarative `IssueLabels`, because they are not in `deploy/repositories/`. Until
their labels are reconciled declaratively, #58 cannot remove *their*
`sync-labels.yaml` without leaving a gap in label management.

The #58 prerequisite is now met: all 15 existing `IssueLabels` reconcile live
(`kubectl -n github-config get issuelabels … Synced=True ReconcileSuccess` for all
15), so extending the same mechanism to the last two repos is safe.

## Change (purely additive — no removals)
- `deploy/labels/actions.yaml` + `deploy/labels/reusable-workflows.yaml`:
  **labels-only** `IssueLabels` CRs (the `dot-github` precedent — a Repository CR
  is **not** required just to manage labels; full repo-management is a separate,
  bigger decision and intentionally out of scope here).
- Both register in `deploy/labels/kustomization.yaml`, so the shared patch appends
  the canonical 22-label taxonomy.
- Each declares the `dependencies` (`0366d6`) + `github_actions` (`000000`)
  ecosystem extras — matching **every** sibling GitHub-Actions repo (go-template,
  dotnet-template, platform-template, gitops-tenant-template, homebrew-tap) so the
  authoritative set does not churn against Dependabot.

## Label-set impact (enumerated against live, since `IssueLabels` is authoritative)
- **actions** — declared set is **set-equal to live** (24 labels: 22 canonical +
  `dependencies` + `github_actions`). **Zero churn.**
- **reusable-workflows** — **adds** `dependencies` + `github_actions` (live has the
  22 canonical only). This is intentional: the old daily label-sync kept deleting
  them while Dependabot recreates them; declaring them ends that churn loop and
  aligns it with its sibling repos.

## Validation
- `kubectl kustomize deploy/` builds clean → **46 resources** (was 44; +2 IssueLabels).
- Rendered label names diffed against each repo's live labels (`gh api …/labels`):
  actions = set-equal; reusable-workflows = +2 as documented above.

## ⚠️ Live-reconcile confirmation (post-merge)
These two repos are not currently Crossplane-managed, so the provider App's access
to them is confirmed only once the CRs reconcile. **Safe failure mode:** if the App
lacks access, the two *new* CRs go `Synced=False` (404/403) — a non-applying
reconcile on new resources that **deletes no labels**; it does not regress any
existing management. Verify after merge with
`kubectl -n github-config get issuelabels actions reusable-workflows` → `Synced=True`.

## Acceptance / next
Unblocks #58 step 2 (removing `sync-labels.yaml`) for the **full** 17-repo set
uniformly, and step 3 (deleting the `actions/sync-github-labels` composite +
`actions/.github/labels.yaml`).

Part of #56. Unblocks #58.
