### PR TITLE
fix(rulesets): use bare numeric external-name for repository rulesets

### DIFF
--- a/deploy/repository-rulesets/README.md
+++ b/deploy/repository-rulesets/README.md
@@ -9,7 +9,11 @@ Org-wide `OrganizationRuleset` resources live in the sibling
 adoption convention and the provider importability matrix.
 
 **One `RepositoryRuleset` per file**, named `<verb>-on-<repo>.yaml` so the rule and its
-target repo are clear from the filename. external-name = `<repo>:<id>`.
+target repo are clear from the filename. external-name = the **bare numeric ruleset id**
+(same as `../organization-rulesets/`; the provider stores `RepositoryRuleset.id`
+from-provider). The Terraform `<repo>:<ruleset_id>` form is the *import* id only — using
+it as the external-name fails the provider's `strconv.ParseInt` so the resource never
+observes.
 
 | File | Repo | Ruleset | Policy |
 |---|---|---|---|

--- a/deploy/repository-rulesets/require-merge-queue-on-platform.yaml
+++ b/deploy/repository-rulesets/require-merge-queue-on-platform.yaml
@@ -1,6 +1,9 @@
 # Existing repository ruleset, adopted Observe-first (read-only). external-name =
-# `<repo>:<ruleset_id>` (cf. the `maintainers:<repo>` convention in
-# ../teams/). Identity-only forProvider — see ./README.md for the convention.
+# the bare numeric ruleset id — the upjet provider stores RepositoryRuleset `id`
+# from-provider, exactly like ../organization-rulesets/. (The Terraform
+# `<repo>:<ruleset_id>` form is the *import* id, NOT the stored external-name; a
+# `<repo>:`-prefixed value fails the provider's strconv.ParseInt and the resource
+# never observes.) Identity-only forProvider — see ./README.md for the convention.
 #
 # platform's "Require merge queue" rule on the default branch (merge_queue is a
 # repo-only rule type; org rulesets cannot carry it).
@@ -9,7 +12,7 @@ kind: RepositoryRuleset
 metadata:
   name: platform-require-merge-queue
   annotations:
-    crossplane.io/external-name: "platform:5275020"
+    crossplane.io/external-name: "5275020" # numeric ruleset id
 spec:
   managementPolicies: ["Observe"]
   forProvider:

--- a/deploy/repository-rulesets/restrict-deletions-on-ksail.yaml
+++ b/deploy/repository-rulesets/restrict-deletions-on-ksail.yaml
@@ -1,6 +1,9 @@
 # Existing repository ruleset, adopted Observe-first (read-only). external-name =
-# `<repo>:<ruleset_id>` (cf. the `maintainers:<repo>` convention in
-# ../teams/). Identity-only forProvider — see ./README.md for the convention.
+# the bare numeric ruleset id — the upjet provider stores RepositoryRuleset `id`
+# from-provider, exactly like ../organization-rulesets/. (The Terraform
+# `<repo>:<ruleset_id>` form is the *import* id, NOT the stored external-name; a
+# `<repo>:`-prefixed value fails the provider's strconv.ParseInt and the resource
+# never observes.) Identity-only forProvider — see ./README.md for the convention.
 #
 # ksail's own "Restrict deletions" rule, scoped to refs/heads/benchmark-data (the
 # long-lived benchmark-data branch) — narrower than the org-wide rule.
@@ -9,7 +12,7 @@ kind: RepositoryRuleset
 metadata:
   name: ksail-restrict-deletions
   annotations:
-    crossplane.io/external-name: "ksail:14699634"
+    crossplane.io/external-name: "14699634" # numeric ruleset id
 spec:
   managementPolicies: ["Observe"]
   forProvider:


### PR DESCRIPTION
## Why

The two `RepositoryRuleset` resources are stuck `SYNCED=False` and the
`provider-upjet-github` controller errors on every reconcile, which Coroot
surfaces on prod as recurring **`CannotObserveExternalResource`** events:

```
observe failed: ... Unexpected ID format ("ksail:14699634"), expected numerical
ID. strconv.ParseInt: parsing "ksail:14699634": invalid syntax
```

## Root cause

`crossplane.io/external-name` was set to the Terraform **import-id** form
`<repo>:<ruleset_id>` (`ksail:14699634`, `platform:5275020`) instead of the
**bare numeric ruleset id** the provider actually stores. `RepositoryRuleset` is
`config.IdentifierFromProvider` — same as the `OrganizationRuleset` siblings in
`../organization-rulesets/`, which all use bare numeric ids (`"6986186"`, …) and
sync fine. The provider `strconv.ParseInt`s the external-name, so the `<repo>:`
prefix makes it unparseable and the resource never observes.

## Fix

Strip the `<repo>:` prefix on both (the numeric part is already the correct id,
verified against the live GitHub API: ksail "Restrict deletions" = `14699634`,
platform "Require merge queue" = `5275020`) and correct the misleading
convention note in both files + the README.

**Blast radius: none.** Both are `managementPolicies: ["Observe"]` (read-only
adoption) — the provider only *reads* GitHub state, so this never modifies the
real rulesets; it just lets the observe succeed and populate `status.atProvider`.

`kubectl kustomize deploy/repository-rulesets/` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)