### PR TITLE
fix(ci): release revert commits so reverts reach the cluster

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,6 +3,13 @@
     "main"
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer"
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "type": "revert", "release": "patch" }
+        ]
+      }
+    ]
   ]
 }


### PR DESCRIPTION
## Problem

The revert #75 (dropping the panic-on-create CodeRabbit ruleset) **merged to main but never deployed**. semantic-release reported:

```
[commit-analyzer] Analysis of 1 commits complete: no release
There are no relevant changes, so no new version is released.
```

The repo's `.releaserc` uses `@semantic-release/commit-analyzer` with **default rules only** (feat/fix/perf) — the `revert` type isn't covered. So no tag was cut, `cd.yaml` never re-published, and the github-config OCI artifact stayed at **v1.8.0** (which still contains the broken ruleset). The failing `OrganizationRuleset` CR is therefore still on-cluster and un-pruned.

This is a latent bug: **any** `revert(...)` PR would silently fail to deploy.

## Fix

Add a `commit-analyzer` `releaseRule` mapping `revert` → `patch`, so revert commits cut a release. Two effects:

1. **This `fix:` commit** (a default release rule) cuts a patch now → `cd.yaml` republishes **current main**, which already has #75's removal applied → Flux prunes the failing CR.
2. **Future `revert(...)` commits** will release, so a revert always reaches the cluster.

Validated: `.releaserc` is valid JSON; `revert`→patch added without dropping the default feat/fix/perf rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation so revert commits now trigger a patch release.
  * Release handling is now more consistent when changes are rolled back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->