### PR TITLE
feat(repositories): declare provider-upjet-unifi (net-new Library repo)

### DIFF
--- a/deploy/labels/kustomization.yaml
+++ b/deploy/labels/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
   - maintenance.yaml
   - agent-skills.yaml
   - agent-plugins.yaml
+  - provider-upjet-unifi.yaml
   - unifi.yaml
   - gitops-tenant-template.yaml
   - platform-template.yaml

--- a/deploy/labels/provider-upjet-unifi.yaml
+++ b/deploy/labels/provider-upjet-unifi.yaml
@@ -1,7 +1,8 @@
 # Issue labels for devantler-tech/provider-upjet-unifi. The canonical org taxonomy
-# is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only this repo's repo-specific extras (the dependency/ecosystem labels
-# Dependabot/Renovate apply). See ../README.md.
+# is appended to every IssueLabels by the shared patch in kustomization.yaml. This
+# repo declares no repo-specific extras yet (`label: []`); add this repo's own
+# dependency/ecosystem labels here (the ones Dependabot/Renovate apply) once they
+# exist, so the authoritative set doesn't strip them. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:

--- a/deploy/labels/provider-upjet-unifi.yaml
+++ b/deploy/labels/provider-upjet-unifi.yaml
@@ -1,0 +1,23 @@
+# Issue labels for devantler-tech/provider-upjet-unifi. The canonical org taxonomy
+# is appended to every IssueLabels by the shared patch in kustomization.yaml; this
+# file adds only this repo's repo-specific extras (the dependency/ecosystem labels
+# Dependabot/Renovate apply). See ../README.md.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: IssueLabels
+metadata:
+  name: provider-upjet-unifi
+  annotations:
+    crossplane.io/external-name: provider-upjet-unifi
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: provider-upjet-unifi
+    # No repo-specific extras; the shared patch supplies the full canonical set.
+    label: []
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - maintenance.yaml
   - agent-skills.yaml
   - agent-plugins.yaml
+  - provider-upjet-unifi.yaml
   - unifi.yaml
   - gitops-tenant-template.yaml
   - platform-template.yaml

--- a/deploy/repositories/provider-upjet-unifi.yaml
+++ b/deploy/repositories/provider-upjet-unifi.yaml
@@ -1,0 +1,27 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: provider-upjet-unifi
+  annotations:
+    # NET-NEW repo (not an adoption): the provider CREATEs it from this manifest.
+    # external-name pinned so the create/observe target is unambiguous.
+    crossplane.io/external-name: provider-upjet-unifi
+spec:
+  # Same all-except-Delete policy as every other managed repo (omitting Delete
+  # guarantees Crossplane can never delete a real GitHub repository). Create is
+  # present so the provider provisions this repo if it does not yet exist.
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: provider-upjet-unifi
+    description: "Crossplane provider for Ubiquiti UniFi, generated with Upjet from ubiquiti-community/terraform-provider-unifi. Manage UniFi networks, WLANs, firewall, VPN/WireGuard, devices and settings as Kubernetes resources."
+    visibility: public
+    hasIssues: true
+    # Shared kustomization patch supplies the squash-only merge policy +
+    # webCommitSignoffRequired; nothing repo-specific needed here.
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-maintainers-on-provider-upjet-unifi.yaml
+++ b/deploy/team-repositories/grant-maintainers-on-provider-upjet-unifi.yaml
@@ -1,0 +1,16 @@
+# Team → repository access. No external-name: this grant did not exist yet (the
+# repo is net-new), so it is Created (full management except Delete) rather than adopted.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: maintainers-provider-upjet-unifi
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: maintainers
+    repository: provider-upjet-unifi
+    permission: maintain
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/kustomization.yaml
+++ b/deploy/team-repositories/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
   - grant-maintainers-on-platform-template.yaml
   - grant-maintainers-on-unifi.yaml
   - grant-maintainers-on-homebrew-tap.yaml
+  - grant-maintainers-on-provider-upjet-unifi.yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Declares **`devantler-tech/provider-upjet-unifi`** as a managed repo in the org's declarative GitHub config:

- `deploy/repositories/provider-upjet-unifi.yaml` — Crossplane `Repository` (public, hasIssues, squash-only/signoff via the shared patch).
- `deploy/labels/provider-upjet-unifi.yaml` — `IssueLabels` (canonical org taxonomy via the shared patch; no repo-specific extras yet).
- Both registered in their `kustomization.yaml` resource lists, grouped with the other shared libraries.

## Why

This repo will hold a new shared library: a **Crossplane provider for Ubiquiti UniFi, generated with Upjet** from [`ubiquiti-community/terraform-provider-unifi`](https://github.com/ubiquiti-community/terraform-provider-unifi) (registry source `ubiquiti-community/unifi`, MPL-2.0). It lets UniFi networks/WLANs/firewall/VPN-WireGuard/devices/settings be managed as Kubernetes CRDs and reconciled by Flux — the same way `platform` already consumes `provider-upjet-github`.

Creating it **declaratively** is the only correct path: the org enforces 5 required custom properties on every new repo (so `gh repo create --template` is blocked), and the repo-specific golden rule is *manage GitHub declaratively — never imperatively*.

## ⚠️ Note for the maintainer — genuine create vs. adoption

Every existing entry in `deploy/repositories/` was **Observe-adopted** from a pre-existing repo; this is the **first create-from-scratch** through the provider. Two things to be aware of when this merges and reconciles:

1. **Required custom properties.** The org schema marks `Type`, `EnableAutoMerge`, `ScanGitHubActions`, `AutomaticallyRequestCopilotCodeReview`, `LintDocumentation` as `required` with `require_explicit_values: true`. `provider-upjet-github`'s `Repository` (v0.19.1) doesn't model custom properties, so the REST create may rely on the org defaults applying, or it may need the property values set out-of-band / a follow-up. If the create 422s on this, the cleanest follow-up is to set `Type=Library` (+ the other four defaults) — happy to do that however you prefer.
2. **`visibility: public` + `hasIssues: true`** are set explicitly here (the adopted entries rely on LateInitialize, which only works for already-public repos).

## Validation

```sh
kubectl kustomize deploy/ > /dev/null   # clean (the required check)
```

## Follow-ups (separate PRs, after the repo exists)

- Push the Upjet-generated provider content (Makefile pointed at `ubiquiti-community/unifi` v0.53.0, all ~27 resources, CI/CD publishing the xpkg to `ghcr.io/devantler-tech/provider-upjet-unifi`, `AGENTS.md`). Built and validated locally already.
- Wire it into the monorepo as a `libraries/provider-upjet-unifi` submodule (+ portfolio row + product skill card).