### PR TITLE
feat(labels): bring devantler-tech/monorepo under declarative IssueLabels management

### DIFF
--- a/deploy/labels/kustomization.yaml
+++ b/deploy/labels/kustomization.yaml
@@ -14,13 +14,15 @@
 # now the single source of truth for that taxonomy. Mirrors the org-wide settings
 # patch in ../repositories/kustomization.yaml.
 #
-# Scope = the repos managed in ../repositories/ + this repo (.github). Bring a new
-# repo under management by adding `<repo>.yaml` with its live extras (enumerate
-# them first so the authoritative set doesn't strip a label in use).
+# Scope = the repos managed in ../repositories/ + this repo (.github) + the
+# monorepo (labels-only for now — it is not yet declared in ../repositories/).
+# Bring a new repo under management by adding `<repo>.yaml` with its live extras
+# (enumerate them first so the authoritative set doesn't strip a label in use).
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - dot-github.yaml
+  - monorepo.yaml
   - platform.yaml
   - ksail.yaml
   - maintenance.yaml

--- a/deploy/labels/monorepo.yaml
+++ b/deploy/labels/monorepo.yaml
@@ -1,0 +1,31 @@
+# Issue labels for devantler-tech/monorepo. The canonical org taxonomy (22 labels)
+# is appended to every IssueLabels by the shared patch in kustomization.yaml; this
+# file adds only the monorepo's repo-specific extras (the dependency/ecosystem
+# labels Dependabot applies — incl. `submodules` for the gitsubmodule ecosystem),
+# declared so the authoritative set doesn't churn against the bots. See ../README.md.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: IssueLabels
+metadata:
+  name: monorepo
+  annotations:
+    crossplane.io/external-name: monorepo
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: monorepo
+    label:
+      - name: "dependencies"
+        color: "0366d6"
+      - name: "github_actions"
+        color: "000000"
+      - name: "javascript"
+        color: "168700"
+      - name: "submodules"
+        color: "000000"
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Part of #58.

## Problem

The label-sync removal sweep (#58, maintainer go-ahead on 2026-06-27 after #64) found a coverage gap: `devantler-tech/monorepo` still runs the old `sync-labels.yaml` workflow but has **no IssueLabels CR** — it is the only repo carrying the workflow that is not yet declaratively managed (verified live: 18 IssueLabels CRs, all Synced+Ready, monorepo absent). Deleting its workflow without this would leave a label-management gap, which #58 explicitly forbids.

## Change

- `deploy/labels/monorepo.yaml` — IssueLabels CR declaring the monorepo's repo-specific extras (`dependencies`, `github_actions`, `javascript`, `submodules` — its live Dependabot ecosystem labels, enumerated from the live repo so the authoritative set strips nothing in use). The shared kustomization patch appends the canonical 22-label taxonomy, same as every other repo.
- `deploy/labels/kustomization.yaml` — register the new file + scope-comment update.

**Scope note (flagged for steering):** this is labels-only — monorepo remains outside `deploy/repositories/` (declaring full repo settings for the monorepo is a bigger call than #58 needs; happy to follow up if wanted).

## Validation

`kubectl kustomize deploy/` renders clean; the monorepo doc carries the 4 extras + canonical taxonomy (19 IssueLabels total).

## Sequencing

The monorepo's `sync-labels.yaml` deletion PR (opened as part of the same sweep) should merge **after** this reconciles, so label management never gaps.