### PR TITLE
ci: repoint reusable workflows to devantler-tech/actions v8.0.0

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,7 +3,7 @@ name: 🚀 CD
 # Publishes the org's declarative GitHub state (deploy/) as a cosign-signed OCI
 # artifact consumed by the platform cluster's `github-config` tenant. There is
 # NO container image here — only manifests — so it delegates to the shared
-# manifests-only publish workflow in devantler-tech/reusable-workflows (the
+# manifests-only publish workflow in devantler-tech/actions (the
 # manifests-only sibling of publish-app.yaml).
 #
 # The OCI path is `github-config` (not the repo name) because `.github` is an
@@ -11,10 +11,12 @@ name: 🚀 CD
 #
 # Because signing runs INSIDE the reusable workflow, the cosign certificate
 # identity (OIDC subject) is that workflow's path —
-# https://github.com/devantler-tech/reusable-workflows/.github/workflows/publish-manifests.yaml@<ref>
+# https://github.com/devantler-tech/actions/.github/workflows/publish-manifests.yaml@<ref>
 # — NOT this repo's cd.yaml. The platform `github-config` OCIRepository's
 # verify.matchOIDCIdentity.subject must match that (see
-# k8s/providers/hetzner/github/sync.yaml in devantler-tech/platform).
+# k8s/bases/apps/github-config/oci-repository.yaml in devantler-tech/platform),
+# so this repo's workflow-source swap MUST land only after the platform
+# verifier accepts the devantler-tech/actions subject.
 
 on:
   push:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,6 +35,6 @@ jobs:
     # Renovate manages this pin, as it does for publish-app.yaml elsewhere.
     # The platform verifier matches `@.+$`, so the ref does not affect cosign
     # verification.
-    uses: devantler-tech/reusable-workflows/.github/workflows/publish-manifests.yaml@f974f62a8cb396130fa084d209ad1fc17e99b9fc # v5.6.1
+    uses: devantler-tech/actions/.github/workflows/publish-manifests.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
     with:
       oci-name: devantler-tech/github-config

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,6 @@ permissions:
 
 jobs:
   release:
-    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@c830916321473ec23bb612e41de963b9b01af897 # v5.6.6
+    uses: devantler-tech/actions/.github/workflows/create-release.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Our reusable CI workflows moved to `devantler-tech/actions`; this repo still builds and signs its releases from the old repo, which can't be archived until everyone moves — and which now fails nightly (reusable-workflows#350).

## What

Points this repo's CI and release workflows at the new home. Same workflows, no behavior change.

Part of devantler-tech/actions#425.

⚠️ **Merge order:** land devantler-tech/platform#2399 first — the platform must trust the new signing home, or this repo's next release is rejected and its deployment stops updating.
👉 **After promotion:** needs a direct merge (auto-merge can't touch workflow files).