### PR TITLE
docs: codify PM-level, short PR descriptions in the org PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,26 @@
-Please include a summary of the changes. **What** has changed and **why**?.
+<!--
+Write for the project manager deciding whether this change is needed — not for
+a code reviewer (CodeRabbit and CI validate correctness). Keep it SHORT:
+1–3 plain-language sentences per section. No code detail — no file paths,
+symbols, snippets, or test/lint output. The change type lives in the PR title
+(Conventional Commits), not here.
+-->
 
-Fixes [url OR #issue]
+## Why
 
-## Type of change
+<!-- The problem this solves and why it matters. -->
 
-Select the appropriate options and delete the rest:
+## What
 
-- [ ] 🧹 Refactor
-- [ ] 🪲 Bug fix
-- [ ] 🚀 New feature
-- [ ] ⛓️‍💥 Breaking change
-- [ ] 📚 Documentation update
+<!-- What the change does, at outcome level. -->
+
+Fixes #
+
+<!--
+Only if applicable — one line each, delete the rest:
+
+⚠️ Merge order: land #N first, or <what breaks>.
+💥 Breaking change: <what breaks, for whom>.
+📦 New dependency: <name> — <why>.
+👉 After merge/promotion: <action the maintainer must take>.
+-->


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

You want PR descriptions readable at PM level — short, why/what only, no code detail. The org template is where that expectation should be defined once for every repo and contributor, instead of living only in my instructions.

## What

Replaces the org-wide PR template with one that asks for exactly that: a short **Why**, a short **What**, the issue link, and optional one-line flags (merge order, breaking change, new dependency, action needed). Drops the type-of-change checkboxes — the PR title already carries the type.

Part of the same policy as devantler-tech/monorepo#2042.