### PR TITLE
feat: declare the devantler-tech/aws config-tenant repo

### DIFF
--- a/deploy/labels/aws.yaml
+++ b/deploy/labels/aws.yaml
@@ -1,0 +1,22 @@
+# Issue labels for devantler-tech/aws. The canonical org taxonomy (22 labels)
+# is appended to every IssueLabels by the shared patch in kustomization.yaml; this
+# file adds only aws's repo-specific extras. See ../README.md.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: IssueLabels
+metadata:
+  name: aws
+  annotations:
+    crossplane.io/external-name: aws
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: aws
+    # No repo-specific extras; the shared patch supplies the full canonical set.
+    label: []
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/labels/kustomization.yaml
+++ b/deploy/labels/kustomization.yaml
@@ -30,6 +30,7 @@ resources:
   - agent-plugins.yaml
   - provider-upjet-unifi.yaml
   - unifi.yaml
+  - aws.yaml
   - gitops-tenant-template.yaml
   - platform-template.yaml
   - go-template.yaml

--- a/deploy/repositories/aws.yaml
+++ b/deploy/repositories/aws.yaml
@@ -1,0 +1,31 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: aws
+  annotations:
+    # NET-NEW repo (not an adoption). The provider's create POST cannot send the
+    # org's 5 required custom properties (no CRD field), so it 422s until the
+    # repo is bootstrapped ONCE by an org admin with `gh api -X POST
+    # /orgs/devantler-tech/repos` including `custom_properties` (Type=
+    # Infrastructure + the 4 defaults) — see platform#2325. This CR then
+    # observes + adopts it and manages it declaratively from there on.
+    # external-name pinned so the create/observe target is unambiguous.
+    crossplane.io/external-name: aws
+spec:
+  # Same all-except-Delete policy as every other managed repo (omitting Delete
+  # guarantees Crossplane can never delete a real GitHub repository).
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: aws
+    description: "Declarative AWS infrastructure for the devantler-tech platform — Crossplane managed resources in deploy/, published as a cosign-signed OCI artifact and reconciled by the platform's aws tenant."
+    visibility: public
+    hasIssues: true
+    # Shared kustomization patch supplies the squash-only merge policy +
+    # webCommitSignoffRequired; nothing repo-specific needed here.
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - agent-plugins.yaml
   - provider-upjet-unifi.yaml
   - unifi.yaml
+  - aws.yaml
   - gitops-tenant-template.yaml
   - platform-template.yaml
   - go-template.yaml

--- a/deploy/team-repositories/grant-maintainers-on-aws.yaml
+++ b/deploy/team-repositories/grant-maintainers-on-aws.yaml
@@ -1,0 +1,16 @@
+# Team → repository access. No external-name: this grant does not exist yet, so it is
+# Created (full management except Delete) rather than adopted.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: maintainers-aws
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: maintainers
+    repository: aws
+    permission: maintain
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/kustomization.yaml
+++ b/deploy/team-repositories/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - grant-maintainers-on-unifi.yaml
   - grant-maintainers-on-homebrew-tap.yaml
   - grant-maintainers-on-provider-upjet-unifi.yaml
+  - grant-maintainers-on-aws.yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The AWS roadmap (platform#2324) needs a home for AWS-as-code: a tenant repo whose manifests the platform's `aws` tenant reconciles, like `github-config` does for this repo. Declaring it here keeps repo management on the declarative source of truth.

## What
Declares the net-new `devantler-tech/aws` repo — Repository CR, maintainers team grant, and issue labels — matching every other managed repo (all-except-Delete policy, shared merge-policy patch).

**Operational note:** the provider cannot create net-new repos (org custom-property gate), so the repo needs the documented one-time admin bootstrap (one-click posted on platform#2325) — merge order doesn't matter; the CR adopts the repo once both exist.

Part of platform#2325.