### PR TITLE
fix: gate repository-permissions/ until provider-upjet-github supports shaPinningRequired

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -22,4 +22,16 @@ resources:
   - labels/
   - organization-rulesets/
   - repository-rulesets/
-  - repository-permissions/
+  # repository-permissions/ is intentionally NOT wired in yet — the
+  # `shaPinningRequired` field it patches onto every RepositoryPermissions is
+  # absent from the currently-deployed provider-upjet-github v0.19.1 CRD
+  # schema (it embeds terraform-provider-github 6.6.0; the field landed in
+  # 6.11.0). Applying it makes dry-run reject the patch and the tenant's
+  # `apps` Kustomization health-check times out after 20m, stalling every
+  # prod deploy and kicking PRs out of the merge queue (hit live 2026-07-09,
+  # ~4h after #67 merged and republished as v1.12.0). Re-add once the
+  # provider bump lands — tracked upstream at
+  # crossplane-contrib/provider-upjet-github#288 (own PR, open, blocked on
+  # maintainer review) — and the repository-permissions/kustomization.yaml
+  # header's own gate note confirms the same precondition.
+  # - repository-permissions/

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -22,16 +22,10 @@ resources:
   - labels/
   - organization-rulesets/
   - repository-rulesets/
-  # repository-permissions/ is intentionally NOT wired in yet — the
-  # `shaPinningRequired` field it patches onto every RepositoryPermissions is
-  # absent from the currently-deployed provider-upjet-github v0.19.1 CRD
-  # schema (it embeds terraform-provider-github 6.6.0; the field landed in
-  # 6.11.0). Applying it makes dry-run reject the patch and the tenant's
-  # `apps` Kustomization health-check times out after 20m, stalling every
-  # prod deploy and kicking PRs out of the merge queue (hit live 2026-07-09,
-  # ~4h after #67 merged and republished as v1.12.0). Re-add once the
-  # provider bump lands — tracked upstream at
-  # crossplane-contrib/provider-upjet-github#288 (own PR, open, blocked on
-  # maintainer review) — and the repository-permissions/kustomization.yaml
-  # header's own gate note confirms the same precondition.
+  # repository-permissions/ is intentionally NOT wired in yet — its own
+  # kustomization.yaml header documents the precondition (provider-upjet-github
+  # bump for `sha_pinning_required`, crossplane-contrib/provider-upjet-github#288).
+  # Hit live 2026-07-09: publishing it stalled the tenant `apps` Kustomization's
+  # health check for 20m every reconcile, blocking prod deploys and the merge
+  # queue. Re-add once that provider bump lands.
   # - repository-permissions/


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
#67's `shaPinningRequired` patch is currently stalling every prod deploy: the field isn't in the deployed Crossplane provider's CRD schema yet, so the tenant's `apps` Kustomization health-check times out after 20 minutes on every reconcile cycle — blocking prod deploys and kicking PRs out of the platform merge queue.

## What
Comments out `repository-permissions/` from the root kustomization until the provider bump lands. The directory and its own gate-note stay in place for when that's ready — nothing is deleted, only un-wired from the published artifact.

## Notes
- Root cause: `provider-upjet-github` v0.19.1 embeds terraform-provider-github 6.6.0; `sha_pinning_required` landed upstream in 6.11.0.
- The fix already exists as my own upstream PR crossplane-contrib/provider-upjet-github#288, open and blocked on maintainer review — re-wire this directory once that ships and we bump the pin.
- `kubectl kustomize deploy/ > /dev/null` validated clean.

Fixes the live prod stall (hit 2026-07-09, ~4h after #67's v1.12.0 publish).