### PR TITLE
feat: archive the reusable-workflows repository (phase 2)

### DIFF
--- a/deploy/archived-repositories/kustomization.yaml
+++ b/deploy/archived-repositories/kustomization.yaml
@@ -5,15 +5,15 @@
 # CRs here get NO shared patches; they carry only what an archived repo can hold.
 #
 # Lifecycle (two-phase, per devantler-tech/actions#425 AC3):
-#   1. Adopt Observe-only (read-only mirror; this phase) and remove the repo's
-#      active management CRs (labels/, repository-permissions/,
-#      team-repositories/) — all omit Delete, so pruning them never touches
-#      live GitHub.
+#   1. Adopt Observe-only (read-only mirror) and remove the repo's active
+#      management CRs (labels/, repository-permissions/, team-repositories/) —
+#      all omit Delete, so pruning them never touches live GitHub.
 #   2. After the org required-workflow rulesets are repointed off the repo
 #      (devantler-tech/.github#87), promote to Observe+Update+LateInitialize
-#      with `archived: true` — LateInitialize backfills the remaining live
-#      settings first, so the only write the provider ever sends is the single
-#      archive PATCH; once archived, desired == observed and it stays silent.
+#      with `archived: true` (reusable-workflows is at this phase) —
+#      LateInitialize backfills the remaining live settings first, so the only
+#      write the provider ever sends is the single archive PATCH; once
+#      archived, desired == observed and it stays silent.
 # Delete is omitted everywhere (same guarantee as ../repositories/: a CR/Flux
 # prune can never delete a real repository).
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/deploy/archived-repositories/reusable-workflows.yaml
+++ b/deploy/archived-repositories/reusable-workflows.yaml
@@ -1,9 +1,12 @@
 # Legacy reusable-workflow library, merged INTO devantler-tech/actions (#314,
-# v7.0.0) and bound for archival (devantler-tech/actions#425 AC3). Phase 1:
-# Observe-only adoption — Crossplane mirrors live state into status.atProvider
-# and never writes. Phase 2 (a follow-up PR, gated on the org required-workflow
-# rulesets repointing off this repo — devantler-tech/.github#87): promote to
-# Observe+Update+LateInitialize and set `archived: true` under forProvider.
+# v7.0.0) and archived per devantler-tech/actions#425 AC3. Phase 2 (this
+# revision): Observe+Update+LateInitialize with `archived: true` —
+# LateInitialize backfills the remaining live settings first, so the only write
+# the provider ever sends is the single archive PATCH; once archived,
+# desired == observed and the reconcile stays silent. MERGE GATE: the org
+# required-workflow rulesets must be repointed off this repo first
+# (devantler-tech/.github#87), or every gated PR org-wide loses its required
+# workflow source.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: Repository
 metadata:
@@ -11,9 +14,10 @@ metadata:
   annotations:
     crossplane.io/external-name: reusable-workflows
 spec:
-  managementPolicies: ["Observe"]
+  managementPolicies: ["Observe", "Update", "LateInitialize"]
   forProvider:
     name: reusable-workflows
+    archived: true
   providerConfigRef:
     kind: ProviderConfig
     name: default


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The reusable-workflows library was merged into `actions` (v7.0.0) months ago, but the repo itself is still un-archived — leaving a legacy surface contributors can mistake for live. Archiving it is the last acceptance criterion of the migration (devantler-tech/actions#425 AC3).

## What

Flips the reusable-workflows Repository CR to managed with `archived: true` — on merge, Crossplane sends the single archive PATCH and the repo becomes read-only. Reversal is UI-only (the provider cannot unarchive).

**⚠️ Merge gate: complete the #87 one-clicks first** — five org required-workflow rulesets still source their required workflow from this repo; archiving before repointing them to `actions` risks breaking every gated PR org-wide.

Part of devantler-tech/actions#425. Unblocked by #88 (phase 1, merged).