### PR TITLE
fix(aws): reconcile the default branch to main

### DIFF
--- a/deploy/repositories/aws.yaml
+++ b/deploy/repositories/aws.yaml
@@ -29,3 +29,23 @@ spec:
   providerConfigRef:
     kind: ProviderConfig
     name: default
+---
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: DefaultBranch
+metadata:
+  name: aws
+  annotations:
+    # The Repository CRD's defaultBranch field is deprecated; manage the
+    # already-existing main branch through the dedicated resource instead.
+    crossplane.io/external-name: aws
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    branch: main
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

`devantler-tech/aws` still defaults to the bootstrap branch even though `main` is the released source of truth. New clones and repository links therefore land on stale configuration.

## What

- add a namespaced `DefaultBranch` managed resource for `aws`
- import the existing repository and reconcile its default to `main`
- permit observe/create/update/late-initialize while explicitly excluding delete
- use the dedicated resource instead of the deprecated `Repository.defaultBranch` field

## Validation

- red/green structural assertion for the rendered AWS default-branch resource
- `kubectl kustomize deploy/`
- `kubectl --context admin@prod apply --dry-run=server -f deploy/repositories/aws.yaml`
- live CRD schema check for `repo.github.m.upbound.io/v1alpha1` `DefaultBranch`
- `git diff --check`
- independent read-only review: no actionable findings

## Notes

The live repository currently reports `claude/aws-config-tenant-scaffold` as its default. Reconciliation after release should switch it to the already-existing `main` branch without changing any unrelated repository settings.

Fixes #89
