### PR TITLE
docs: complete agent and deploy contributor guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -45,6 +45,21 @@ out-of-band changes made in the GitHub UI.
   and activation of `repositorypermissions.actions.github.m.upbound.io` in the
   platform MRAP.
 
+## Roadmap
+
+GitHub Issues are the roadmap of record. Epic
+[#56](https://github.com/devantler-tech/.github/issues/56) tracks the current
+GitHub-as-code programme in three phases:
+
+1. **Foundation** — publish the signed artifact and Observe-adopt repositories,
+   teams, and provider credentials without assuming delete ownership (landed).
+2. **Coverage** — extend the declarative source of truth across labels,
+   rulesets, team access, repository metadata, and remaining org settings
+   through the epic's linked children (active).
+3. **Enforcement** — move each supported object from observation to active
+   reconciliation only after its live state matches the manifest; retain the
+   no-`Delete` policy until deletion is explicitly designed and reviewed.
+
 ## Credentials & refresh behavior
 
 The provider authenticates as a GitHub App whose credentials are **not** stored

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -45,6 +45,37 @@ out-of-band changes made in the GitHub UI.
   and activation of `repositorypermissions.actions.github.m.upbound.io` in the
   platform MRAP.
 
+## Credentials & refresh behavior
+
+The provider authenticates as a GitHub App whose credentials are **not** stored
+here: [`external-secret.yaml`](external-secret.yaml) is an
+[External Secrets](https://external-secrets.io) `ExternalSecret` that syncs them
+from the platform cluster's OpenBao `SecretStore` into the `github-app-credentials`
+Secret consumed by [`provider-config.yaml`](provider-config.yaml), re-reading the
+source every `refreshInterval: 1h`. Two operational consequences:
+
+- **A credential rotated in OpenBao propagates within the hour** — no manifest
+  change or redeploy needed.
+- **OpenBao being unreachable does not break reconciliation immediately**: the
+  ExternalSecret reports `SecretSynced=False` but the last-synced Secret stays in
+  place, so Crossplane keeps reconciling on cached credentials until a refresh
+  succeeds (or the credentials themselves expire). A `SecretSynced=False` alone is
+  therefore a degraded-refresh signal, not an outage of the github-config tenant.
+
+## Authoring changes
+
+The authoring conventions live in the repo's [`AGENTS.md`](../AGENTS.md) (the
+canonical instructions file, for humans and AI agents alike) — in short:
+declarative-only (never `gh api` writes or UI changes to managed config),
+**Observe-first** adoption of live objects (`crossplane.io/external-name` +
+a management policy excluding `Delete`), team-based ownership, and
+`IssueLabels` declared as a complete superset of a repo's live labels. Validate
+before every PR with exactly what CI runs:
+
+```sh
+kubectl kustomize deploy/ > /dev/null
+```
+
 See the platform repo's
 [`docs/github-management.md`](https://github.com/devantler-tech/platform/blob/main/docs/github-management.md)
 for the architecture, the GitHub App credential setup, and the **Observe-first**

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -72,9 +72,10 @@ source every `refreshInterval: 1h`. Two operational consequences:
 - **A credential rotated in OpenBao propagates within the hour** — no manifest
   change or redeploy needed.
 - **OpenBao being unreachable does not break reconciliation immediately**: the
-  ExternalSecret reports `SecretSynced=False` but the last-synced Secret stays in
-  place, so Crossplane keeps reconciling on cached credentials until a refresh
-  succeeds (or the credentials themselves expire). A `SecretSynced=False` alone is
+  ExternalSecret's `Ready` condition goes `False` (typically with reason
+  `SecretSyncedError`) but the last-synced Secret stays in place, so Crossplane
+  keeps reconciling on cached credentials until a refresh succeeds (or the
+  credentials themselves expire). A `Ready=False` refresh error alone is
   therefore a degraded-refresh signal, not an outage of the github-config tenant.
 
 ## Authoring changes


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

#55 tracks this repo's missing agent/contributor guidance. Root `AGENTS.md` already delivered the canonical rules; this PR completes the remaining tool shims and the operational guidance contributors need when changing `deploy/`.

## What

- adds one-line `CLAUDE.md` and `GEMINI.md` shims to canonical `AGENTS.md`;
- documents OpenBao-backed GitHub App credential refresh and degraded-refresh behavior;
- points contributors to the declarative authoring rules and exact CI validation command;
- adds a concise three-phase roadmap anchored on epic #56.

## Scope reconciliation

- A separate `.github/copilot-instructions.md` is intentionally not reintroduced: Copilot code review gained root `AGENTS.md` support on 2026-06-18, so the canonical file serves that reviewer directly.
- Repo-specific Crossplane rules remain out of `.github/CONTRIBUTING.md`, which is the organization-wide default community-health file; they live in `AGENTS.md` and `deploy/README.md` instead.

## Validation

- `kubectl kustomize deploy/ > /dev/null`
- `git diff --check`
- both tool shims verified as exactly one line: `@AGENTS.md`

Fixes #55
