### PR TITLE
feat(repos): declare devantler-tech/kyverno-policies (shared Kyverno policy library)

### DIFF
--- a/deploy/labels/kustomization.yaml
+++ b/deploy/labels/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
   - provider-upjet-unifi.yaml
   - unifi.yaml
   - aws.yaml
+  - kyverno-policies.yaml
   - gitops-tenant-template.yaml
   - platform-template.yaml
   - go-template.yaml

--- a/deploy/labels/kyverno-policies.yaml
+++ b/deploy/labels/kyverno-policies.yaml
@@ -1,0 +1,22 @@
+# Issue labels for devantler-tech/kyverno-policies. The canonical org taxonomy (22 labels)
+# is appended to every IssueLabels by the shared patch in kustomization.yaml; this
+# file adds only kyverno-policies's repo-specific extras. See ../README.md.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: IssueLabels
+metadata:
+  name: kyverno-policies
+  annotations:
+    crossplane.io/external-name: kyverno-policies
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: kyverno-policies
+    # No repo-specific extras; the shared patch supplies the full canonical set.
+    label: []
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - provider-upjet-unifi.yaml
   - unifi.yaml
   - aws.yaml
+  - kyverno-policies.yaml
   - gitops-tenant-template.yaml
   - platform-template.yaml
   - go-template.yaml

--- a/deploy/repositories/kyverno-policies.yaml
+++ b/deploy/repositories/kyverno-policies.yaml
@@ -1,0 +1,51 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: kyverno-policies
+  annotations:
+    # NET-NEW repo (not an adoption). The provider's create POST cannot send the
+    # org's 5 required custom properties (no CRD field), so it 422s until the
+    # repo is bootstrapped ONCE by an org admin with `gh api -X POST
+    # /orgs/devantler-tech/repos` including `custom_properties` (Type=
+    # Infrastructure + the 4 defaults) — see platform#2325. This CR then
+    # observes + adopts it and manages it declaratively from there on.
+    # external-name pinned so the create/observe target is unambiguous.
+    crossplane.io/external-name: kyverno-policies
+spec:
+  # Same all-except-Delete policy as every other managed repo (omitting Delete
+  # guarantees Crossplane can never delete a real GitHub repository).
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: kyverno-policies
+    description: "Shared Kyverno policy library for the devantler-tech platforms — the single source the platform and platform-template consume instead of vendoring per-repo copies."
+    visibility: public
+    hasIssues: true
+    # Shared kustomization patch supplies the squash-only merge policy +
+    # webCommitSignoffRequired; nothing repo-specific needed here.
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default
+---
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: DefaultBranch
+metadata:
+  name: kyverno-policies
+  annotations:
+    # The Repository CRD's defaultBranch field is deprecated; manage the
+    # already-existing main branch through the dedicated resource instead.
+    crossplane.io/external-name: kyverno-policies
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    branch: main
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-maintainers-on-kyverno-policies.yaml
+++ b/deploy/team-repositories/grant-maintainers-on-kyverno-policies.yaml
@@ -1,0 +1,16 @@
+# Team → repository access. No external-name: this grant does not exist yet, so it is
+# Created (full management except Delete) rather than adopted.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: maintainers-kyverno-policies
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: maintainers
+    repository: kyverno-policies
+    permission: maintain
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/kustomization.yaml
+++ b/deploy/team-repositories/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - grant-maintainers-on-homebrew-tap.yaml
   - grant-maintainers-on-provider-upjet-unifi.yaml
   - grant-maintainers-on-aws.yaml
+  - grant-maintainers-on-kyverno-policies.yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
Both the platform and platform-template vendor their own Kyverno policy copies; platform-template's five oldest enhancement issues (platform-template#3–#7) have been gated for a month on the shared policy repo existing. Declaring it unblocks that whole theme.

## What
Adds the `kyverno-policies` Repository + DefaultBranch CRs to the org's declarative repo config (net-new pattern copied from `aws.yaml`, all-except-Delete policies).

Operational note: after promotion, the repo needs the documented ONE-TIME org-admin bootstrap POST with the required custom properties (platform#2325 pattern) before the CR adopts it.

Part of platform-template#24 (theme 1)