### PR TITLE
feat(teams): add default-off Admins policy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,9 @@ jobs:
         # CRDs are applied/validated on-cluster, not here.
         run: kubectl kustomize deploy/ > /dev/null
 
+      - name: 🧪 Test default-off Admins policy
+        run: bash tests/admin-team-policy.sh
+
   ci-required-checks:
     name: CI - Required Checks
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,10 @@ for the architecture, the GitHub App credential setup, and the Observe-first ado
 | Path | Contents |
 |---|---|
 | `deploy/repositories/<repo>.yaml` | one `Repository` per managed repo (settings, merge/signoff, metadata) |
-| `deploy/teams/` | the `maintainers` team and its `TeamRepository` → repo access bindings |
+| `deploy/teams/` | one `Team` per file; default-off teams remain unlisted until activation |
+| `deploy/team-memberships/` | one explicit user-to-team membership per file |
+| `deploy/team-repositories/` | one team-to-repository permission grant per file |
+| `tests/fixtures/` | validation-only enabled renders for default-off policy slices |
 | `deploy/labels/<repo>.yaml` | one `IssueLabels` per repo; canonical taxonomy in `labels/kustomization.yaml` |
 | `deploy/provider-config.yaml` | the provider-upjet-github `ProviderConfig` (App credentials) |
 | `deploy/external-secret.yaml` | the `ExternalSecret` sourcing the GitHub App credentials |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,10 +19,13 @@ out-of-band changes made in the GitHub UI.
   targets a read-only repo (each patched reconcile would 422). Observe-first,
   then a single `archived: true` flip; the two-phase lifecycle is documented in
   that dir's `kustomization.yaml`.
-- `teams/` — one `Team` per file (the `maintainers` team, Observe-adopted).
+- `teams/` — one `Team` per file. `maintainers` is Observe-adopted; the
+  separate `admins` policy remains default-off until its resources are listed.
 - `team-memberships/` — one `TeamMembership` per file (`add-<user>-to-<team>.yaml`).
 - `team-repositories/` — one `TeamRepository` per file (`grant-<team>-on-<repo>.yaml`),
-  each granting a team a permission on a repo.
+  each granting a team a permission on a repo. A file is inert until its
+  directory Kustomization lists it; the Admins policy uses this as its
+  default-off activation boundary.
 - `labels/` — one `IssueLabels` per managed repo. The canonical org label
   taxonomy lives once in `labels/kustomization.yaml` (a shared patch appended to
   every repo); each `<repo>.yaml` adds only that repo's Dependabot/Renovate
@@ -97,3 +100,25 @@ See the platform repo's
 for the architecture, the GitHub App credential setup, and the **Observe-first**
 adoption flow for bringing an existing repository under management without any
 risk of recreating or deleting it.
+
+## Default-off Admins policy
+
+Issue [#95](https://github.com/devantler-tech/.github/issues/95) defines the
+separate `Admins` team, its explicit maintainer membership, and `admin`
+grants for the 19 active portfolio repositories. The archived
+`reusable-workflows` repository and not-yet-active `kyverno-policies`
+repository are excluded.
+
+The policy files deliberately remain absent from the production
+`teams/`, `team-memberships/`, and `team-repositories/` resource lists.
+Validate both states with:
+
+```sh
+kubectl kustomize deploy/ > /dev/null
+kubectl kustomize tests/fixtures/admin-team-enabled \
+  --load-restrictor LoadRestrictionsNone > /dev/null
+bash tests/admin-team-policy.sh
+```
+
+Activation is a separate issue-backed change that lists the reviewed policy
+files in those three production Kustomizations.

--- a/deploy/team-memberships/add-devantler-to-admins.yaml
+++ b/deploy/team-memberships/add-devantler-to-admins.yaml
@@ -1,0 +1,16 @@
+# Default-off Admins-team membership. Activation lists this file alongside the
+# team and grants in their three production Kustomizations.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamMembership
+metadata:
+  name: admins-devantler
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    username: devantler
+    role: maintainer
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-actions.yaml
+++ b/deploy/team-repositories/grant-admins-on-actions.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-actions
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: actions
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-agent-plugins.yaml
+++ b/deploy/team-repositories/grant-admins-on-agent-plugins.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-agent-plugins
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: agent-plugins
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-agent-skills.yaml
+++ b/deploy/team-repositories/grant-admins-on-agent-skills.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-agent-skills
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: agent-skills
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-ascoachingogvaner.yaml
+++ b/deploy/team-repositories/grant-admins-on-ascoachingogvaner.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-ascoachingogvaner
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: ascoachingogvaner
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-aws.yaml
+++ b/deploy/team-repositories/grant-admins-on-aws.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-aws
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: aws
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-dot-github.yaml
+++ b/deploy/team-repositories/grant-admins-on-dot-github.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-dot-github
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: .github
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-dotnet-template.yaml
+++ b/deploy/team-repositories/grant-admins-on-dotnet-template.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-dotnet-template
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: dotnet-template
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-fleet-gitops.yaml
+++ b/deploy/team-repositories/grant-admins-on-fleet-gitops.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-fleet-gitops
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: fleet-gitops
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-gitops-tenant-template.yaml
+++ b/deploy/team-repositories/grant-admins-on-gitops-tenant-template.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-gitops-tenant-template
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: gitops-tenant-template
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-go-template.yaml
+++ b/deploy/team-repositories/grant-admins-on-go-template.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-go-template
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: go-template
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-homebrew-tap.yaml
+++ b/deploy/team-repositories/grant-admins-on-homebrew-tap.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-homebrew-tap
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: homebrew-tap
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-ksail.yaml
+++ b/deploy/team-repositories/grant-admins-on-ksail.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-ksail
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: ksail
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-maintenance.yaml
+++ b/deploy/team-repositories/grant-admins-on-maintenance.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-maintenance
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: maintenance
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-monorepo.yaml
+++ b/deploy/team-repositories/grant-admins-on-monorepo.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-monorepo
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: monorepo
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-platform-template.yaml
+++ b/deploy/team-repositories/grant-admins-on-platform-template.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-platform-template
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: platform-template
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-platform.yaml
+++ b/deploy/team-repositories/grant-admins-on-platform.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-platform
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: platform
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-provider-upjet-unifi.yaml
+++ b/deploy/team-repositories/grant-admins-on-provider-upjet-unifi.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-provider-upjet-unifi
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: provider-upjet-unifi
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-unifi.yaml
+++ b/deploy/team-repositories/grant-admins-on-unifi.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-unifi
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: unifi
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-admins-on-wedding-app.yaml
+++ b/deploy/team-repositories/grant-admins-on-wedding-app.yaml
@@ -1,0 +1,17 @@
+# Default-off Admins-team repository grant. No external-name is set because the
+# separate team and its admin grant do not exist yet; activation creates them
+# without claiming Delete management.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-wedding-app
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: wedding-app
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/teams/admins.yaml
+++ b/deploy/teams/admins.yaml
@@ -1,0 +1,18 @@
+# Default-off feature policy: the separate administrative team chosen for
+# repository-admin grants. This file is intentionally omitted from
+# deploy/teams/kustomization.yaml. Activation lists the team, membership, and
+# grants in their three production Kustomizations.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: Team
+metadata:
+  name: admins
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    createDefaultMaintainer: false
+    description: Repository administrators for the devantler-tech portfolio
+    name: Admins
+    privacy: secret
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/tests/admin-team-policy.sh
+++ b/tests/admin-team-policy.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+disabled_render="$(mktemp)"
+enabled_render="$(mktemp)"
+policy_source="$(mktemp)"
+trap 'rm -f "$disabled_render" "$enabled_render" "$policy_source"' EXIT
+
+kubectl kustomize "$repo_root/deploy" >"$disabled_render"
+kubectl kustomize "$repo_root/tests/fixtures/admin-team-enabled" \
+  --load-restrictor LoadRestrictionsNone >"$enabled_render"
+
+fail() {
+  echo "admins-policy test: $*" >&2
+  exit 1
+}
+
+require_count() {
+  local expected="$1" pattern="$2" file="$3" actual
+  actual="$(grep -Ec "$pattern" "$file" || true)"
+  [[ "$actual" == "$expected" ]] ||
+    fail "expected $expected matches for '$pattern', got $actual"
+}
+
+require_fixed_count() {
+  local expected="$1" value="$2" file="$3" actual
+  actual="$(grep -Fxc "$value" "$file" || true)"
+  [[ "$actual" == "$expected" ]] ||
+    fail "expected $expected exact matches for '$value', got $actual"
+}
+
+if grep -Eq '^  name: admins($|-)' "$disabled_render"; then
+  fail "Admins resources must stay disabled in the deploy/ root render"
+fi
+
+require_count 1 '^  name: admins$' "$enabled_render"
+require_count 1 '^  name: admins-devantler$' "$enabled_render"
+require_count 20 '^  name: admins-' "$enabled_render"
+require_count 19 '^    permission: admin$' "$enabled_render"
+require_count 20 '^      name: admins$' "$enabled_render"
+
+grant_files=("$repo_root"/deploy/team-repositories/grant-admins-on-*.yaml)
+policy_files=(
+  "$repo_root/deploy/teams/admins.yaml"
+  "$repo_root/deploy/team-memberships/add-devantler-to-admins.yaml"
+  "${grant_files[@]}"
+)
+[[ "${#grant_files[@]}" == 19 ]] ||
+  fail "expected 19 Admins grants, got ${#grant_files[@]}"
+[[ "${#policy_files[@]}" == 21 ]] ||
+  fail "expected 21 Admins policy files, got ${#policy_files[@]}"
+cat "${policy_files[@]}" >"$policy_source"
+
+repositories=(
+  .github
+  actions
+  agent-plugins
+  agent-skills
+  ascoachingogvaner
+  aws
+  dotnet-template
+  fleet-gitops
+  gitops-tenant-template
+  go-template
+  homebrew-tap
+  ksail
+  maintenance
+  monorepo
+  platform
+  platform-template
+  provider-upjet-unifi
+  unifi
+  wedding-app
+)
+
+for repository in "${repositories[@]}"; do
+  require_fixed_count 1 "    repository: ${repository}" "$policy_source"
+done
+
+require_count 0 '^    repository: reusable-workflows$' "$policy_source"
+require_count 0 '^    repository: kyverno-policies$' "$policy_source"
+
+if grep -Eq '^[[:space:]]*managementPolicies:.*Delete|crossplane.io/external-name' \
+  "${policy_files[@]}"; then
+  fail "net-new Admins resources must not claim Delete or an external name"
+fi
+
+require_count 1 '^    createDefaultMaintainer: false$' "$enabled_render"
+require_count 1 '^    privacy: secret$' "$enabled_render"
+
+for maintainers_grant in "$repo_root"/deploy/team-repositories/grant-maintainers-on-*.yaml; do
+  grep -Eq '^    permission: maintain$' "$maintainers_grant" ||
+    fail "existing Maintainers permission changed in $maintainers_grant"
+done

--- a/tests/fixtures/admin-team-enabled/kustomization.yaml
+++ b/tests/fixtures/admin-team-enabled/kustomization.yaml
@@ -1,0 +1,28 @@
+# Test-only enabled render for the default-off Admins policy. Production stays
+# disabled because the canonical teams, memberships, and grants are not listed
+# by their deploy/ kustomizations.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../deploy
+  - ../../../deploy/teams/admins.yaml
+  - ../../../deploy/team-memberships/add-devantler-to-admins.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-dot-github.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-actions.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-agent-plugins.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-agent-skills.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-ascoachingogvaner.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-aws.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-dotnet-template.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-fleet-gitops.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-gitops-tenant-template.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-go-template.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-homebrew-tap.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-ksail.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-maintenance.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-monorepo.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-platform.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-platform-template.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-provider-upjet-unifi.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-unifi.yaml
+  - ../../../deploy/team-repositories/grant-admins-on-wedding-app.yaml


### PR DESCRIPTION
> 🤖 Generated by the Codex Daily AI Engineer instance.

## Summary

- define a separate secret `Admins` team without claiming Delete management
- add an explicit `devantler` maintainer membership
- declare `admin` grants for the 19 approved active portfolio repositories
- add an enabled validation fixture and a CI policy test

## Why

The maintainer chose a separate Admins team so repository-admin privileges stay isolated from the canonical Maintainers team. This is the first child increment of #53.

The policy is deliberately **default-off**: none of the new team, membership, or grant files is listed in the three production Kustomizations. Merging this definition cannot change live organization permissions. Activation remains a separate issue-backed review step.

The archived `reusable-workflows` repository and not-yet-active `kyverno-policies` repository are excluded.

## Validation

- `bash tests/admin-team-policy.sh`
- `kubectl kustomize deploy/`
- `kubectl kustomize tests/fixtures/admin-team-enabled --load-restrictor LoadRestrictionsNone`
- `shellcheck tests/admin-team-policy.sh`
- `actionlint .github/workflows/ci.yaml`
- `git diff --check`

Parent: #53

Fixes #95