### PR TITLE
feat(repo-permissions): bring devantler-tech/actions under SHA-pin policy

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -39,11 +39,12 @@ out-of-band changes made in the GitHub UI.
 - `repository-permissions/` — one `RepositoryPermissions` per managed repo enforcing
   **Require actions to be pinned to a full-length commit SHA**
   (`sha_pinning_required`). The policy is asserted once via a shared patch in
-  `repository-permissions/kustomization.yaml`; scope is every repo in `labels/`
-  **except `actions`**. Requires a provider-upjet-github release embedding
-  terraform-provider-github ≥ 6.11.0 (the field is absent in the deployed v0.19.1)
-  and activation of `repositorypermissions.actions.github.m.upbound.io` in the
-  platform MRAP.
+  `repository-permissions/kustomization.yaml`; scope is **every repo in `labels/`**
+  (`actions` included — its former exception was removed once its tag-pins were
+  reverted). Live enforcement is still gated on a provider-upjet-github release
+  embedding terraform-provider-github ≥ 6.11.0 (the field is absent in the deployed
+  v0.19.1) and activation of `repositorypermissions.actions.github.m.upbound.io` in
+  the platform MRAP.
 
 ## Roadmap
 

--- a/deploy/repository-permissions/actions.yaml
+++ b/deploy/repository-permissions/actions.yaml
@@ -1,0 +1,27 @@
+# Actions permissions for devantler-tech/actions — binds the org-wide
+# shaPinningRequired policy (asserted once in kustomization.yaml) to this repo.
+# Observe+LateInitialize adopts the repo's live enabled/allowedActions so turning
+# on SHA-pinning never disturbs them. See ../README.md.
+#
+# Previously excluded while this repo's first-party self-references were tag-pinned
+# (release-please rewrote them per release). Those accommodations were reverted in
+# devantler-tech/actions#541 — self-references now resolve by local path after a
+# same-commit self-checkout and every remote `uses:` is SHA-pinned — so the repo
+# now joins the org-wide policy (devantler-tech/actions#426).
+apiVersion: actions.github.m.upbound.io/v1alpha1
+kind: RepositoryPermissions
+metadata:
+  name: actions
+  annotations:
+    crossplane.io/external-name: actions
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: actions
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repository-permissions/kustomization.yaml
+++ b/deploy/repository-permissions/kustomization.yaml
@@ -11,9 +11,10 @@
 # repo's live `enabled`/`allowedActions` first, so turning SHA-pinning on never
 # disturbs them.
 #
-# Scope = every repo managed in ../labels/ EXCEPT `actions`
-# (devantler-tech/actions is intentionally excluded). Bring a new repo under this
-# policy by adding `<repo>.yaml` here.
+# Scope = every repo managed in ../labels/. `actions` joined the policy in
+# devantler-tech/actions#426 once its first-party tag-pin accommodations were
+# reverted (actions#541) — it had been excluded only while those tags existed.
+# Bring a new repo under this policy by adding `<repo>.yaml` here.
 #
 # REQUIRES a provider-upjet-github release embedding terraform-provider-github
 # >= 6.11.0 (where `sha_pinning_required` was added). The field is ABSENT in the
@@ -25,6 +26,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - dot-github.yaml
+  - actions.yaml
   - platform.yaml
   - ksail.yaml
   - maintenance.yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

**Why.** `devantler-tech/actions` was the one repo left out of the org-wide "require actions to be pinned to a full-length commit SHA" policy — excluded only while its first-party self-references were tag-pinned. Those tag-pin accommodations were reverted in devantler-tech/actions#541 (self-references now resolve by local path; every remote action is SHA-pinned), so the exclusion is obsolete and the repo should hold itself to the same hardening it enforces everywhere else.

**What.** Adds `actions.yaml` to `deploy/repository-permissions/` and registers it in the kustomization, so the shared `shaPinningRequired: true` patch now covers `actions` too. Updates the header note that recorded the old exclusion.

Delivers the declarative source-of-truth for AC1 of actions#426 (AC2/AC3 already landed via actions#541). Live effect awaits the same provider-upjet-github#288 provider bump that gates this entire directory — no behaviour change until then.

Part of devantler-tech/actions#426