### PR TITLE
docs(repositories): correct kyverno bootstrap contract

### DIFF
--- a/deploy/repositories/kyverno-policies.yaml
+++ b/deploy/repositories/kyverno-policies.yaml
@@ -5,9 +5,10 @@ metadata:
   annotations:
     # Adopted repo. The provider CRD cannot represent the org's 5 required
     # custom properties, so the initial org-admin bootstrap had to set them
-    # through GitHub's API. The intended classification is Type=Library; see
-    # https://github.com/devantler-tech/.github/issues/97 for the exact
-    # property contract and the remaining provider gap. This CR manages every
+    # through GitHub's API. Type=Library is the intended and current
+    # classification; AutomaticallyRequestCopilotCodeReview=true remains
+    # outstanding. See https://github.com/devantler-tech/.github/issues/97
+    # for the exact property contract and provider gap. This CR manages every
     # representable setting declaratively after adoption.
     # external-name pinned so the create/observe target is unambiguous.
     crossplane.io/external-name: kyverno-policies

--- a/deploy/repositories/kyverno-policies.yaml
+++ b/deploy/repositories/kyverno-policies.yaml
@@ -3,12 +3,12 @@ kind: Repository
 metadata:
   name: kyverno-policies
   annotations:
-    # NET-NEW repo (not an adoption). The provider's create POST cannot send the
-    # org's 5 required custom properties (no CRD field), so it 422s until the
-    # repo is bootstrapped ONCE by an org admin with `gh api -X POST
-    # /orgs/devantler-tech/repos` including `custom_properties` (Type=
-    # Infrastructure + the 4 defaults) — see platform#2325. This CR then
-    # observes + adopts it and manages it declaratively from there on.
+    # Adopted repo. The provider CRD cannot represent the org's 5 required
+    # custom properties, so the initial org-admin bootstrap had to set them
+    # through GitHub's API. The intended classification is Type=Library; see
+    # https://github.com/devantler-tech/.github/issues/97 for the exact
+    # property contract and the remaining provider gap. This CR manages every
+    # representable setting declaratively after adoption.
     # external-name pinned so the create/observe target is unambiguous.
     crossplane.io/external-name: kyverno-policies
 spec:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Summary

- document that `kyverno-policies` is now an adopted repository
- correct its copied `Type=Infrastructure` bootstrap guidance to `Type=Library`
- replace the unrelated AWS tracker with the exact `.github#97` property contract
- keep the GitHub API exception scoped to the completed one-time org-admin bootstrap

## Why

The repository and all representable Crossplane resources are reconciled, but the committed comment still describes a net-new Infrastructure repository and points to the AWS bootstrap. That stale guidance would reproduce the wrong custom-property contract on a future recovery.

The provider CRD still cannot represent custom properties. This PR only documents the adopted state; it does not make an imperative repository-setting change. `.github#97` remains open for the one outstanding org-admin correction: set `AutomaticallyRequestCopilotCodeReview=true` while retaining `Type=Library`.

## Validation

- failing-first assertion for the `Type=Library` + `.github#97` contract
- `kubectl kustomize deploy/`
- `git diff --check`
- independent review: no actionable findings after correcting the issue contract and narrowing the API exception

Related to #97.
