### PR TITLE
fix(release): suppress issue side effects

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,14 +5,12 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  id-token: write
+permissions: {}
 
 jobs:
   release:
-    uses: devantler-tech/actions/.github/workflows/create-release.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
+    uses: devantler-tech/actions/.github/workflows/create-release.yaml@47f0d9b632581a613963a2d25c243713f24c32a0 # v10.1.0
+    with:
+      disable-issue-side-effects: true
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Org configuration is an active release consumer. Post-publication semantic-release issue hooks can turn an otherwise successful release red, and the caller currently grants permissions the reusable workflow does not need.

## What

- Pin the reusable release workflow to Actions v10.1.0.
- Opt out of semantic-release issue and pull-request side effects.
- Replace the caller's top-level token grants with `permissions: {}` while preserving its triggers and App secret.

Fixes #108
Part of devantler-tech/actions#610
