### PR TITLE
feat(repositories): declare discovery topics for the agent libraries

### DIFF
--- a/deploy/repositories/agent-plugins.yaml
+++ b/deploy/repositories/agent-plugins.yaml
@@ -10,8 +10,9 @@ metadata:
     crossplane.io/external-name: agent-plugins
 spec:
   # Squash-only merge policy + webCommitSignoffRequired come from the shared
-  # patch; description is declared here so the config is AUTHORITATIVE for it
-  # (previously LateInitialized); everything else is adopted via LateInitialize.
+  # patch; description and topics are declared here so the config is
+  # AUTHORITATIVE for them (description was previously LateInitialized, topics
+  # were unset); everything else is adopted via LateInitialize.
   managementPolicies:
     - Observe
     - Create
@@ -19,7 +20,14 @@ spec:
     - LateInitialize
   forProvider:
     name: agent-plugins
-    description: "Industry-standard agent-plugin marketplace — bundles curated skills from devantler-tech/skills into category-based plugins for VS Code, GitHub Copilot CLI, and Claude Code (dual manifests)."
+    # Fixes a stale repo reference: `devantler-tech/skills` was renamed to
+    # `devantler-tech/agent-skills`, so the old description pointed at a name
+    # that no longer exists. Also names the bundled MCP servers and agents —
+    # the marketplace is deliberately not skills-only.
+    description: "Tool-neutral agent-plugin marketplace — bundles curated skills, MCP servers and agents from devantler-tech/agent-skills into category plugins for VS Code, GitHub Copilot CLI, and Claude Code"
+    # Discovery surface — the repo carried no topics at all, so it was invisible
+    # to every topic-based browse and directory crawl.
+    topics: ["agent-plugins", "agent-skills", "ai-agents", "claude-code", "claude-code-marketplace", "claude-code-plugin", "claude-plugin", "github-copilot", "plugin-marketplace", "vscode"]
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/agent-skills.yaml
+++ b/deploy/repositories/agent-skills.yaml
@@ -11,8 +11,9 @@ metadata:
     crossplane.io/external-name: agent-skills
 spec:
   # Squash-only merge policy + webCommitSignoffRequired come from the shared
-  # patch; description is declared here so the config is AUTHORITATIVE for it
-  # (previously LateInitialized); everything else is adopted via LateInitialize.
+  # patch; description and topics are declared here so the config is
+  # AUTHORITATIVE for them (description was previously LateInitialized, topics
+  # were unset); everything else is adopted via LateInitialize.
   managementPolicies:
     - Observe
     - Create
@@ -20,7 +21,16 @@ spec:
     - LateInitialize
   forProvider:
     name: agent-skills
-    description: "Generic Copilot / agent skills, installable via gh skill"
+    # De-Copilot-branded: these skills are agent-neutral (agentskills.io spec)
+    # and install into Claude Code, Cursor, Codex and Gemini CLI as well, via
+    # either `gh skill install` or `npx skills add`. The old wording undersold
+    # that and read as Copilot-only.
+    description: "Agent-neutral skills for Claude Code, Copilot, Cursor and Codex — install with `gh skill install` or `npx skills add`"
+    # Discovery surface. `gh skill publish --tag` runs non-interactively in
+    # cd.yaml and therefore SKIPS the interactive "add the agent-skills topic"
+    # step, so the canonical topic was never applied — this declares it instead.
+    # The rest are the terms users actually browse/search by.
+    topics: ["agent-skills", "agent-skill", "ai-agents", "claude-code", "claude-skill", "codex", "cursor", "github-copilot", "gitops", "kubernetes", "skills"]
   providerConfigRef:
     kind: ProviderConfig
     name: default


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Neither `agent-skills` nor `agent-plugins` carried a single GitHub topic, so both were invisible to every topic-based browse and directory crawl — people looking for exactly what we publish could not find it. Two repo descriptions were also wrong: one pointed at a repo name that no longer exists after a rename, the other described the skills as Copilot-only when they work across Claude Code, Cursor and Codex too.

## What

Declares the discovery topics and corrects both descriptions in the Crossplane repo config, so GitHub's own browse and search surfaces list these libraries alongside the other well-known skill and plugin collections. No change to how anything installs — this is purely about being findable.

Part of devantler-tech/monorepo#2229