### PR TITLE
fix(labels): adopt world-at-ruin labels with the full policy set

### DIFF
--- a/deploy/labels/world-at-ruin.yaml
+++ b/deploy/labels/world-at-ruin.yaml
@@ -2,10 +2,10 @@
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
 # file adds only world-at-ruin's repo-specific extras (none yet). See ../README.md.
 #
-# Observe-only for now: this CR binds to a pre-existing repo whose live labels it
-# has not yet observed — with Update active from the first deploy it could replace
-# the live label set before adoption. Promote to the full policy set (all except
-# Delete) once Synced/Ready shows the observed state matches the declared one.
+# Adopted 2026-07-18: the CR reported Synced/Ready on the live cluster, which is the
+# promotion condition the Observe-only bootstrap set out, so it now carries the same
+# policy set as every other repo. Additive only — no Delete policy is claimed, and the
+# five labels the repo already had are all members of the canonical set.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
@@ -15,6 +15,9 @@ metadata:
 spec:
   managementPolicies:
     - Observe
+    - Create
+    - Update
+    - LateInitialize
   forProvider:
     repository: world-at-ruin
     # No repo-specific extras; the shared patch supplies the full canonical set.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

World at Ruin's issues can't be triaged. The repo has only 5 labels — no `bug`, `documentation`,
`refactor`, `security` or `needs triage` — because its label resource was left in observe-only mode
when the repo was bootstrapped, and the follow-up step to actually start applying labels was never
taken. It is the only one of 21 repositories still in that state. Issue #124 is sitting untriaged
right now for exactly this reason: no label fits it.

## What

Switches world-at-ruin's labels to the same managed mode every other repo already uses, so the
standard 22-label set gets applied.

Additive only — the five labels it already has are all part of the standard set, and nothing grants
permission to delete labels, so no existing label is removed or recoloured. The rendered output
changes by exactly three lines, all of them the mode itself.

The condition the bootstrap set for making this switch — the resource reporting healthy against
the live org — is met.

Fixes #116
Part of #56
