### PR TITLE
fix(release): treat `type!:` commits as breaking

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,8 +7,18 @@
       "@semantic-release/commit-analyzer",
       {
         "releaseRules": [
-          { "type": "revert", "release": "patch" }
-        ]
+          {
+            "type": "revert",
+            "release": "patch"
+          },
+          {
+            "breaking": true,
+            "release": "major"
+          }
+        ],
+        "parserOpts": {
+          "breakingHeaderPattern": "^(\\w*)(?:\\((.*)\\))?!: (.*)$"
+        }
       }
     ]
   ]


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

A bang-style breaking commit — `feat!: …` — currently produces **no release at all** in this repo.
Not a wrong version: no release, so a breaking change ships unversioned and nobody downstream learns
the API broke.

semantic-release's default preset only recognises a `BREAKING CHANGE:` footer, while the org's
commit-message ruleset explicitly permits the bang — so contributors are invited to write exactly
the form that silently does nothing.

## What

Makes `type!:` cut a major release. Nothing else changes: `feat:` → minor, `fix:` → patch,
`docs:`/`chore:`/`ci:` → no release, and the `BREAKING CHANGE:` footer keeps working. Any existing
release rules in this repo are preserved.

Safe to merge now — this repo has **no unreleased bang commits**, so nothing jumps a major on merge.

Part of devantler-tech/actions#653
