### PR TITLE
fix(repositories): keep org signoff out of updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: 🧪 Test declarative coverage
         run: bash tests/declarative-coverage.sh
 
+      - name: 🧪 Test repository update policy
+        run: bash tests/repository-update-policy.sh
+
   ci-required-checks:
     name: CI - Required Checks
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,11 @@ for the architecture, the GitHub App credential setup, and the Observe-first ado
 - **Observe-first when adopting an existing resource.** A new `Repository`/`IssueLabels`/team CR for
   an already-live object must adopt it without risk of recreate/delete: set the
   `crossplane.io/external-name` annotation to the live name and use a management policy that
-  **excludes `Delete`** (observe/late-initialize), per platform's `docs/github-management.md`. Verify
+  **excludes `Delete`** (observe/late-initialize), per platform's `docs/github-management.md`. After
+  observation, active `Repository` resources use `Observe`/`Create`/`Update` without
+  `LateInitialize`: only explicitly declared fields belong in update payloads. Org-owned create
+  defaults such as `webCommitSignoffRequired` belong in `initProvider`, where Crossplane applies
+  them only during creation. Verify
   the provider kind/field schema against the authoritative source
   ([crossplane-contrib/provider-upjet-github `package/crds/`](https://github.com/crossplane-contrib/provider-upjet-github)
   + `examples-generated/namespaced/`) — the CRs cannot be schema-validated locally (no cluster; CI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,10 @@ structure; implementing PRs use `Fixes #N`.
 kubectl kustomize deploy/ > /dev/null   # must build clean
 bash tests/admin-team-policy.sh         # Admins policy invariants
 bash tests/declarative-coverage.sh      # every repo declared in every rendered dimension
+bash tests/repository-update-policy.sh  # active Repository update invariants
 ```
 
-Those three commands are exactly what `ci.yaml` runs.
+Those four commands are exactly what `ci.yaml` runs.
 
 `kubectl` (with built-in kustomize) is preinstalled on CI runners. A clean build proves the manifests
 are well-formed; the Crossplane CRDs themselves are applied/validated **on-cluster** (the

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -1,14 +1,15 @@
 # One file per managed repository. Adoption is Observe-first: a repo starts with
 # managementPolicies: ["Observe"] (read-only — Crossplane mirrors live state into
 # status.atProvider and never writes), then forProvider is set and the policy
-# promoted to the full set EXCEPT Delete. Namespaced managed resources have no
-# deletionPolicy; omitting Delete is what guarantees Crossplane can never delete
-# a real GitHub repository. See devantler-tech/platform docs/github-management.md.
+# promoted to Observe/Create/Update. The active shared patch deliberately omits
+# both Delete (a real GitHub repository can never be deleted) and LateInitialize
+# (live-only fields must not leak into later update payloads). See
+# devantler-tech/platform docs/github-management.md.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # Actively managed (managementPolicies all-except-Delete). Every non-archived
-  # org repo; the shared merge-policy patch below applies to all of them.
+  # Actively managed. Every non-archived org repo; the shared policy patch below
+  # applies the safe update contract to all of them.
   - platform.yaml
   - ksail.yaml
   - maintenance.yaml
@@ -32,17 +33,27 @@ resources:
 # (auto-applies to every future repo):
 #  - squash-only merge policy (merge commits + rebase disabled; auto-merge,
 #    auto-delete head branches, always-suggest-updating-PR-branches enabled).
-#  - webCommitSignoffRequired: true — the org ENFORCES commit signoff and it
-#    can't be disabled per-repo, so the provider must always send true (else an
-#    update PATCH gets 422 "Commit signoff is enforced ... and cannot be
-#    disabled"). The 12 already-adopted repos had this true via LateInitialize;
-#    pinning it here makes every repo's update self-consistent and robust.
+#  - webCommitSignoffRequired: true at CREATE time only. The org ENFORCES
+#    signoff, so sending the field on an unrelated repository update makes
+#    GitHub reject the whole PATCH. initProvider preserves the secure default
+#    for new repositories without enforcing the org-owned field afterward.
+#  - no LateInitialize. Otherwise the observed signoff value is copied back into
+#    forProvider and poisons the next unrelated update despite initProvider.
 patches:
   - target:
       group: repo.github.m.upbound.io
       version: v1alpha1
       kind: Repository
     patch: |-
+      - op: replace
+        path: /spec/managementPolicies
+        value:
+          - Observe
+          - Create
+          - Update
+      - op: add
+        path: /spec/initProvider
+        value: {}
       - op: add
         path: /spec/forProvider/allowSquashMerge
         value: true
@@ -62,5 +73,5 @@ patches:
         path: /spec/forProvider/deleteBranchOnMerge
         value: true
       - op: add
-        path: /spec/forProvider/webCommitSignoffRequired
+        path: /spec/initProvider/webCommitSignoffRequired
         value: true

--- a/tests/repository-update-policy.sh
+++ b/tests/repository-update-policy.sh
@@ -29,18 +29,24 @@ active_count="$(printf '%s\n' "$active_repositories" | grep -c . || true)"
 [[ "$active_count" -ge 10 ]] ||
   fail "active Repository set collapsed to $active_count entries"
 
-late_initialized="$(
+unsafe_policies="$(
   yq -N '
     select(
       .kind == "Repository" and
       .spec.forProvider.archived != true and
-      (.spec.managementPolicies | contains(["LateInitialize"]))
+      (
+        ((.spec.managementPolicies | length) != 3) or
+        (
+          (.spec.managementPolicies | contains(["Create", "Observe", "Update"])) !=
+          true
+        )
+      )
     ) |
     .metadata.name
   ' "$render"
 )"
-[[ -z "$late_initialized" ]] ||
-  fail "active Repository resources still allow LateInitialize: $late_initialized"
+[[ -z "$unsafe_policies" ]] ||
+  fail "active Repository resources must use only Observe/Create/Update: $unsafe_policies"
 
 update_payload_signoff="$(
   yq -N '

--- a/tests/repository-update-policy.sh
+++ b/tests/repository-update-policy.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+render="$(mktemp)"
+trap 'rm -f "$render"' EXIT
+
+fail() {
+  echo "repository-update-policy test: $*" >&2
+  exit 1
+}
+
+for tool in kubectl yq; do
+  command -v "$tool" >/dev/null || fail "required tool '$tool' not found"
+done
+
+kubectl kustomize "$repo_root/deploy" >"$render" ||
+  fail "kubectl kustomize deploy/ failed"
+[[ -s "$render" ]] || fail "rendered output is empty"
+
+active_repositories="$(
+  yq -N '
+    select(.kind == "Repository" and .spec.forProvider.archived != true) |
+    .metadata.name
+  ' "$render"
+)"
+active_count="$(printf '%s\n' "$active_repositories" | grep -c . || true)"
+[[ "$active_count" -ge 10 ]] ||
+  fail "active Repository set collapsed to $active_count entries"
+
+late_initialized="$(
+  yq -N '
+    select(
+      .kind == "Repository" and
+      .spec.forProvider.archived != true and
+      (.spec.managementPolicies | contains(["LateInitialize"]))
+    ) |
+    .metadata.name
+  ' "$render"
+)"
+[[ -z "$late_initialized" ]] ||
+  fail "active Repository resources still allow LateInitialize: $late_initialized"
+
+update_payload_signoff="$(
+  yq -N '
+    select(
+      .kind == "Repository" and
+      .spec.forProvider.archived != true and
+      (.spec.forProvider | has("webCommitSignoffRequired"))
+    ) |
+    .metadata.name
+  ' "$render"
+)"
+[[ -z "$update_payload_signoff" ]] ||
+  fail "org-controlled signoff remains in forProvider: $update_payload_signoff"
+
+missing_create_signoff="$(
+  yq -N '
+    select(
+      .kind == "Repository" and
+      .spec.forProvider.archived != true and
+      .spec.initProvider.webCommitSignoffRequired != true
+    ) |
+    .metadata.name
+  ' "$render"
+)"
+[[ -z "$missing_create_signoff" ]] ||
+  fail "create-only signoff is missing from initProvider: $missing_create_signoff"
+
+echo "repository-update-policy: OK — $active_count active repositories keep signoff create-only"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

GitHub rejects every declarative Repository update when the provider includes the organization-controlled web commit-signoff field in an unrelated repo PATCH. This leaves repository settings drift unapplied.

## What

- keep active repositories on Observe/Create/Update without LateInitialize
- move the enforced signoff default to create-only initProvider
- add a rendered-policy regression test and run it in CI
- document the active Repository lifecycle in the canonical agent guidance

The security floor stays intact: new repositories still request signoff, Delete remains excluded, and unrelated settings can reconcile without dropping the control.

## Validation

- RED: all active Repository resources rendered with LateInitialize
- GREEN: repository-update-policy, admin-team-policy, and declarative-coverage tests pass
- kubectl kustomize deploy succeeds
- installed CRD server-side dry-run accepts the exact rendered agent-plugins resource

Fixes #112
