### PR TITLE
feat(repositories): declare the doggy-countdown repository

### DIFF
--- a/deploy/labels/doggy-countdown.yaml
+++ b/deploy/labels/doggy-countdown.yaml
@@ -1,0 +1,26 @@
+# Issue labels for devantler-tech/doggy-countdown. The canonical org taxonomy (22 labels)
+# is appended to every IssueLabels by the shared patch in kustomization.yaml; this
+# file adds only doggy-countdown's repo-specific extras (the dependency/ecosystem labels
+# Dependabot/Renovate apply), declared so the authoritative set doesn't churn
+# against the bots. See ../README.md.
+#
+# The repo carries no ecosystem labels, so the extras list is empty and the
+# canonical taxonomy alone is authoritative here.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: IssueLabels
+metadata:
+  name: doggy-countdown
+  annotations:
+    crossplane.io/external-name: doggy-countdown
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: doggy-countdown
+    label: []
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/labels/kustomization.yaml
+++ b/deploy/labels/kustomization.yaml
@@ -43,6 +43,7 @@ resources:
   - wedding-app.yaml
   - fleet-gitops.yaml
   - world-at-ruin.yaml
+  - doggy-countdown.yaml
 # Canonical org-wide label taxonomy, appended to EVERY IssueLabels (single source
 # of truth — was actions/.github/labels.yaml). Verbatim names + colours from that
 # file so the switch from label-sync to Crossplane changes no labels.

--- a/deploy/repositories/doggy-countdown.yaml
+++ b/deploy/repositories/doggy-countdown.yaml
@@ -1,0 +1,25 @@
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: doggy-countdown
+  annotations:
+    crossplane.io/external-name: doggy-countdown
+spec:
+  # Actively managed (everything except Delete). Merge policy from the shared
+  # patch. PRIVATE repo: visibility is pinned private explicitly (never left to
+  # inference) so management can never expose it, and archived false so it can't
+  # be archived. description is declared so the config is AUTHORITATIVE for it;
+  # LateInitialize adopts every other setting.
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: doggy-countdown
+    visibility: private
+    archived: false
+    description: "A countdown to the day Simba the Cocker Spaniel comes home."
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
   # Private repos.
   - ascoachingogvaner.yaml
   - wedding-app.yaml
+  - doggy-countdown.yaml
   - fleet-gitops.yaml
 # Org-wide repo settings applied to EVERY Repository, single source of truth
 # (auto-applies to every future repo):

--- a/deploy/team-repositories/grant-admins-on-doggy-countdown.yaml
+++ b/deploy/team-repositories/grant-admins-on-doggy-countdown.yaml
@@ -1,0 +1,16 @@
+# Admins-team repository grant. No external-name is set because the separate
+# team and its admin grant are created declaratively without claiming Delete.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: admins-doggy-countdown
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: doggy-countdown
+    permission: admin
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/grant-maintainers-on-doggy-countdown.yaml
+++ b/deploy/team-repositories/grant-maintainers-on-doggy-countdown.yaml
@@ -1,0 +1,16 @@
+# Team → repository access. No external-name: this grant does not exist yet, so it is
+# Created (full management except Delete) rather than adopted.
+apiVersion: team.github.m.upbound.io/v1alpha1
+kind: TeamRepository
+metadata:
+  name: maintainers-doggy-countdown
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  forProvider:
+    teamIdRef:
+      name: maintainers
+    repository: doggy-countdown
+    permission: maintain
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/deploy/team-repositories/kustomization.yaml
+++ b/deploy/team-repositories/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - grant-maintainers-on-aws.yaml
   - grant-maintainers-on-kyverno-policies.yaml
   - grant-maintainers-on-world-at-ruin.yaml
+  - grant-maintainers-on-doggy-countdown.yaml
   # Active Admins policy (one admin grant per active repository).
   - grant-admins-on-dot-github.yaml
   - grant-admins-on-actions.yaml
@@ -44,3 +45,4 @@ resources:
   - grant-admins-on-unifi.yaml
   - grant-admins-on-wedding-app.yaml
   - grant-admins-on-world-at-ruin.yaml
+  - grant-admins-on-doggy-countdown.yaml

--- a/tests/admin-team-policy.sh
+++ b/tests/admin-team-policy.sh
@@ -30,9 +30,9 @@ require_fixed_count() {
 
 require_count 1 '^  name: admins$' "$production_render"
 require_count 1 '^  name: admins-devantler$' "$production_render"
-require_count 22 '^  name: admins-' "$production_render"
-require_count 21 '^    permission: admin$' "$production_render"
-require_count 22 '^      name: admins$' "$production_render"
+require_count 23 '^  name: admins-' "$production_render"
+require_count 22 '^    permission: admin$' "$production_render"
+require_count 23 '^      name: admins$' "$production_render"
 
 grant_files=("$repo_root"/deploy/team-repositories/grant-admins-on-*.yaml)
 policy_files=(
@@ -40,10 +40,10 @@ policy_files=(
   "$repo_root/deploy/team-memberships/add-devantler-to-admins.yaml"
   "${grant_files[@]}"
 )
-[[ "${#grant_files[@]}" == 21 ]] ||
-  fail "expected 21 Admins grants, got ${#grant_files[@]}"
-[[ "${#policy_files[@]}" == 23 ]] ||
-  fail "expected 23 Admins policy files, got ${#policy_files[@]}"
+[[ "${#grant_files[@]}" == 22 ]] ||
+  fail "expected 22 Admins grants, got ${#grant_files[@]}"
+[[ "${#policy_files[@]}" == 24 ]] ||
+  fail "expected 24 Admins policy files, got ${#policy_files[@]}"
 cat "${policy_files[@]}" >"$policy_source"
 
 repositories=(
@@ -53,6 +53,7 @@ repositories=(
   agent-skills
   ascoachingogvaner
   aws
+  doggy-countdown
   dotnet-template
   fleet-gitops
   gitops-tenant-template


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A new app repository, `doggy-countdown`, was created for a personal project — a countdown to the day a puppy comes home. The standing rule is that GitHub configuration is managed declaratively, so a repository that exists only imperatively is drift from the moment it is created.

## What

Declares the new repository in the same shape as the other private tenants: actively managed, visibility pinned private, never deletable, never archivable.

This is the adoption half of the documented bootstrap — the repo itself had to be created imperatively because the provider cannot send the org's five required custom properties on create. Everything after this is declarative.

Part of setting up the `doggy-countdown` tenant.
