### PR TITLE
fix(repositories): declare doggy-countdown public so a reconcile cannot unpublish it

### DIFF
--- a/deploy/repositories/doggy-countdown.yaml
+++ b/deploy/repositories/doggy-countdown.yaml
@@ -6,10 +6,10 @@ metadata:
     crossplane.io/external-name: doggy-countdown
 spec:
   # Actively managed (everything except Delete). Merge policy from the shared
-  # patch. PRIVATE repo: visibility is pinned private explicitly (never left to
-  # inference) so management can never expose it, and archived false so it can't
-  # be archived. description is declared so the config is AUTHORITATIVE for it;
-  # LateInitialize adopts every other setting.
+  # patch. PUBLIC repo: visibility is pinned public explicitly (never left to
+  # inference) so a reconcile can never take the published site private, and
+  # archived false so it can't be archived. description is declared so the
+  # config is AUTHORITATIVE for it; LateInitialize adopts every other setting.
   managementPolicies:
     - Observe
     - Create
@@ -17,7 +17,7 @@ spec:
     - LateInitialize
   forProvider:
     name: doggy-countdown
-    visibility: private
+    visibility: public
     archived: false
     description: "A countdown to the day Simba the Cocker Spaniel comes home."
   providerConfigRef:

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -24,10 +24,10 @@ resources:
   - dotnet-template.yaml
   - homebrew-tap.yaml
   - world-at-ruin.yaml
+  - doggy-countdown.yaml
   # Private repos.
   - ascoachingogvaner.yaml
   - wedding-app.yaml
-  - doggy-countdown.yaml
   - fleet-gitops.yaml
 # Org-wide repo settings applied to EVERY Repository, single source of truth
 # (auto-applies to every future repo):


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`doggy-countdown` was declared private when it was created, then made public once it became a published site. The declaration was never updated, so the config now says one thing and the repository is another.

That matters more than it looks: the declared value is what a reconcile applies. Right now nothing applies it (#123), but the moment that is fixed, this file would take a **live public site private** — which is exactly the failure this PR exists to prevent, and exactly what #123 warns is already queued up for two other repositories.

## What

Declares the repository public, and moves it out of the private grouping so the file reads the way it behaves.

The comment is corrected too. It previously claimed the pin existed "so management can never expose it" — the opposite of what is now wanted; it now says the pin exists so a reconcile can never take the published site private.

Declared and live now agree, so this repository is safe under either order of fixing #123.
