### PR TITLE
fix(repositories): pin hasDownloads so reconciliation stops 422-ing

### DIFF
--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -38,6 +38,16 @@ resources:
 #    update PATCH gets 422 "Commit signoff is enforced ... and cannot be
 #    disabled"). The 12 already-adopted repos had this true via LateInitialize;
 #    pinning it here makes every repo's update self-consistent and robust.
+#  - hasDownloads: false — GitHub has removed the downloads feature and no
+#    longer returns the field, so status.atProvider never carries it. The
+#    Terraform provider still defaults it to true, so any repo whose spec picked
+#    that default up through LateInitialize holds a value the API can never
+#    report back. That is an unresolvable diff: the provider sees spec != live on
+#    every reconcile and issues an update PATCH forever. Those PATCHes are then
+#    rejected wholesale (422, on the commit-signoff field), so NO declared
+#    setting reaches GitHub for that repository — visibility included. Pinning
+#    the field to the value the API actually reflects is what stops the diff, and
+#    therefore what keeps the rest of this file enforceable.
 patches:
   - target:
       group: repo.github.m.upbound.io
@@ -65,3 +75,6 @@ patches:
       - op: add
         path: /spec/forProvider/webCommitSignoffRequired
         value: true
+      - op: add
+        path: /spec/forProvider/hasDownloads
+        value: false


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Declarative GitHub org management has not been applying anything. 17 of the 20 managed repositories are stuck in a failing sync state, and every one of them simultaneously reports itself healthy — which is why this ran for weeks without surfacing. While it lasts, no declared setting reaches GitHub for those repositories, including the visibility pins that two repositories' comments describe as the thing stopping management from ever exposing them. That guarantee has not existed.

The cause is not the commit-signoff setting the error message names. That one is already declared correctly and has been since June, so the obvious fix would have changed nothing. The real trigger is a setting GitHub has retired: it is still declared as on, GitHub no longer reports it at all, and the two can therefore never agree. Reconciliation keeps trying to correct it, and each attempt is rejected in full — taking every other declared setting down with it.

## What

Declares that retired setting as off, matching what GitHub actually reflects, so the mismatch disappears.

Evidence: across all 20 managed repositories, agreement on this one setting predicts sync state exactly — all 17 that disagree are failing, all 3 that agree are healthy. No other setting divides the two groups.

**Confidence, stated honestly:** the correlation is exact, but the mechanism is inferred rather than observed — the live mirror these resources publish is demonstrably incomplete, so it cannot be used to prove which comparison reconciliation actually acts on. This is the best-supported single explanation, and it is cheap and reversible; if it is wrong it is a no-op rather than a regression. Confirmation is that the failing repositories return to a healthy sync state after this deploys, and I will verify that and report back on the issue.

Scope is the active repository set only. The archived repository is deliberately excluded — it is the one case where this value genuinely agrees today, so pinning it there would create the very mismatch this removes.

**Needs your call, not fixed here:** two repositories are declared private while live public. This change cannot flip them, but it does not resolve them either — and which of the two is the mistake is a judgement about intent on two live public sites. Evidence is on the issue.

Part of #123
