### PR TITLE
fix(repositories): keep org-enforced signoff out of update payloads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: 🧪 Test declarative coverage
         run: bash tests/declarative-coverage.sh
 
+      - name: 🧪 Test repository update policy
+        run: bash tests/repository-update-policy.sh
+
   ci-required-checks:
     name: CI - Required Checks
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,12 @@ for the architecture, the GitHub App credential setup, and the Observe-first ado
 - **Observe-first when adopting an existing resource.** A new `Repository`/`IssueLabels`/team CR for
   an already-live object must adopt it without risk of recreate/delete: set the
   `crossplane.io/external-name` annotation to the live name and use a management policy that
-  **excludes `Delete`** (observe/late-initialize), per platform's `docs/github-management.md`. Verify
+  **excludes `Delete`** (observe/late-initialize), per platform's `docs/github-management.md`. Once
+  adopted, an active `Repository` runs on `Observe`/`Create`/`Update` **without `LateInitialize`**:
+  late-initialized values land in `forProvider`, and everything in `forProvider` is sent on every
+  subsequent update PATCH. An org-enforced create default such as `webCommitSignoffRequired` belongs
+  in `initProvider`, which Crossplane applies only at creation — GitHub rejects the whole PATCH with
+  422 whenever that field appears in an update. Verify
   the provider kind/field schema against the authoritative source
   ([crossplane-contrib/provider-upjet-github `package/crds/`](https://github.com/crossplane-contrib/provider-upjet-github)
   + `examples-generated/namespaced/`) — the CRs cannot be schema-validated locally (no cluster; CI
@@ -79,9 +84,10 @@ structure; implementing PRs use `Fixes #N`.
 kubectl kustomize deploy/ > /dev/null   # must build clean
 bash tests/admin-team-policy.sh         # Admins policy invariants
 bash tests/declarative-coverage.sh      # every repo declared in every rendered dimension
+bash tests/repository-update-policy.sh  # active Repository update invariants
 ```
 
-Those three commands are exactly what `ci.yaml` runs.
+Those four commands are exactly what `ci.yaml` runs.
 
 `kubectl` (with built-in kustomize) is preinstalled on CI runners. A clean build proves the manifests
 are well-formed; the Crossplane CRDs themselves are applied/validated **on-cluster** (the

--- a/deploy/repositories/agent-plugins.yaml
+++ b/deploy/repositories/agent-plugins.yaml
@@ -17,7 +17,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: agent-plugins
     # Fixes a stale repo reference: `devantler-tech/skills` was renamed to

--- a/deploy/repositories/agent-plugins.yaml
+++ b/deploy/repositories/agent-plugins.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   # Squash-only merge policy + webCommitSignoffRequired come from the shared
   # patch; description and topics are declared here so the config is
-  # AUTHORITATIVE for them (description was previously LateInitialized, topics
-  # were unset); everything else is adopted via LateInitialize.
+  # AUTHORITATIVE for them. Settings declared nowhere here keep the value adopted
+  # from the live repo when it was first observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/agent-skills.yaml
+++ b/deploy/repositories/agent-skills.yaml
@@ -12,8 +12,8 @@ metadata:
 spec:
   # Squash-only merge policy + webCommitSignoffRequired come from the shared
   # patch; description and topics are declared here so the config is
-  # AUTHORITATIVE for them (description was previously LateInitialized, topics
-  # were unset); everything else is adopted via LateInitialize.
+  # AUTHORITATIVE for them. Settings declared nowhere here keep the value adopted
+  # from the live repo when it was first observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/agent-skills.yaml
+++ b/deploy/repositories/agent-skills.yaml
@@ -18,7 +18,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: agent-skills
     # De-Copilot-branded: these skills are agent-neutral (agentskills.io spec)

--- a/deploy/repositories/ascoachingogvaner.yaml
+++ b/deploy/repositories/ascoachingogvaner.yaml
@@ -5,16 +5,15 @@ metadata:
   annotations:
     crossplane.io/external-name: ascoachingogvaner
 spec:
-  # Actively managed (everything except Delete). Merge policy from the shared
-  # patch. PRIVATE repo: visibility is pinned private explicitly (never left to
-  # inference) so management can never expose it, and archived false so it can't
-  # be archived. description is declared so the config is AUTHORITATIVE for it
-  # (previously LateInitialized); LateInitialize adopts every other setting.
+  # Observe-only: this file declares `visibility: private` while the live
+  # repository is public and serving a site, so acting on the declaration would
+  # take the site off the public internet. Which side is wrong is the
+  # maintainer's call, tracked on devantler-tech/.github#123 — until it is made,
+  # Crossplane mirrors this repo read-only and writes nothing. Restoring
+  # Create/Update is what enacts the decision, once `visibility` below has been
+  # set to the answer.
   managementPolicies:
     - Observe
-    - Create
-    - Update
-    - LateInitialize
   forProvider:
     name: ascoachingogvaner
     visibility: private

--- a/deploy/repositories/aws.yaml
+++ b/deploy/repositories/aws.yaml
@@ -18,7 +18,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: aws
     description: "Declarative AWS infrastructure for the devantler-tech platform — Crossplane managed resources in deploy/, published as a cosign-signed OCI artifact and reconciled by the platform's aws tenant."

--- a/deploy/repositories/doggy-countdown.yaml
+++ b/deploy/repositories/doggy-countdown.yaml
@@ -9,8 +9,9 @@ spec:
   # patch. PUBLIC repo: visibility is pinned public explicitly (never left to
   # inference) so a reconcile can never take the published site private, and
   # archived false so it can't be archived. description is declared so the
-  # config is AUTHORITATIVE for it. Settings declared nowhere here keep the value
-  # adopted from the live repo when it was first observed.
+  # config is AUTHORITATIVE for it. Settings in neither
+  # are unmanaged: nothing new is copied into the spec, and values adopted
+  # earlier stay.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/doggy-countdown.yaml
+++ b/deploy/repositories/doggy-countdown.yaml
@@ -14,7 +14,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: doggy-countdown
     visibility: public

--- a/deploy/repositories/doggy-countdown.yaml
+++ b/deploy/repositories/doggy-countdown.yaml
@@ -5,11 +5,12 @@ metadata:
   annotations:
     crossplane.io/external-name: doggy-countdown
 spec:
-  # Actively managed (everything except Delete). Merge policy from the shared
+  # Managed (Observe/Create/Update). Merge policy from the shared
   # patch. PUBLIC repo: visibility is pinned public explicitly (never left to
   # inference) so a reconcile can never take the published site private, and
   # archived false so it can't be archived. description is declared so the
-  # config is AUTHORITATIVE for it; LateInitialize adopts every other setting.
+  # config is AUTHORITATIVE for it. Settings declared nowhere here keep the value
+  # adopted from the live repo when it was first observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/dotnet-template.yaml
+++ b/deploy/repositories/dotnet-template.yaml
@@ -14,7 +14,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: dotnet-template
     description: "A simple .NET template for new projects."

--- a/deploy/repositories/dotnet-template.yaml
+++ b/deploy/repositories/dotnet-template.yaml
@@ -5,11 +5,11 @@ metadata:
   annotations:
     crossplane.io/external-name: dotnet-template
 spec:
-  # Managed (all except Delete). forProvider now declares the discoverability
-  # metadata (description/topics) so the config is AUTHORITATIVE for it
-  # (previously LateInitialized from live); the org-wide squash-only merge policy
-  # still comes from the shared patch in kustomization.yaml, and every other
-  # setting is still adopted unchanged from the live repo via LateInitialize.
+  # Managed (Observe/Create/Update). forProvider declares the discoverability
+  # metadata (description/topics), so the config is AUTHORITATIVE for it; the
+  # org-wide squash-only merge policy comes from the shared patch in
+  # kustomization.yaml. Settings named in neither keep the value adopted from the
+  # live repo when it was first observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/dotnet-template.yaml
+++ b/deploy/repositories/dotnet-template.yaml
@@ -8,8 +8,9 @@ spec:
   # Managed (Observe/Create/Update). forProvider declares the discoverability
   # metadata (description/topics), so the config is AUTHORITATIVE for it; the
   # org-wide squash-only merge policy comes from the shared patch in
-  # kustomization.yaml. Settings named in neither keep the value adopted from the
-  # live repo when it was first observed.
+  # kustomization.yaml. Settings in neither
+  # are unmanaged: nothing new is copied into the spec, and values adopted
+  # earlier stay.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/fleet-gitops.yaml
+++ b/deploy/repositories/fleet-gitops.yaml
@@ -5,11 +5,12 @@ metadata:
   annotations:
     crossplane.io/external-name: fleet-gitops
 spec:
-  # Actively managed (everything except Delete). Merge policy from the shared
+  # Managed (Observe/Create/Update). Merge policy from the shared
   # patch. PRIVATE repo: visibility is pinned private explicitly (never left to
   # inference) so management can never expose it, and archived false so it can't
-  # be archived. description is declared so the config is AUTHORITATIVE for it
-  # (previously LateInitialized); LateInitialize adopts every other setting.
+  # be archived. description is declared so the config is AUTHORITATIVE for it.
+  # Settings declared nowhere here keep the value adopted from the live repo when
+  # it was first observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/fleet-gitops.yaml
+++ b/deploy/repositories/fleet-gitops.yaml
@@ -9,8 +9,9 @@ spec:
   # patch. PRIVATE repo: visibility is pinned private explicitly (never left to
   # inference) so management can never expose it, and archived false so it can't
   # be archived. description is declared so the config is AUTHORITATIVE for it.
-  # Settings declared nowhere here keep the value adopted from the live repo when
-  # it was first observed.
+  # Settings in neither
+  # are unmanaged: nothing new is copied into the spec, and values adopted
+  # earlier stay.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/fleet-gitops.yaml
+++ b/deploy/repositories/fleet-gitops.yaml
@@ -14,7 +14,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: fleet-gitops
     visibility: private

--- a/deploy/repositories/gitops-tenant-template.yaml
+++ b/deploy/repositories/gitops-tenant-template.yaml
@@ -5,11 +5,11 @@ metadata:
   annotations:
     crossplane.io/external-name: gitops-tenant-template
 spec:
-  # Managed (all except Delete). forProvider now declares the discoverability
-  # metadata (description/topics) so the config is AUTHORITATIVE for it
-  # (previously LateInitialized from live); the org-wide squash-only merge policy
-  # still comes from the shared patch in kustomization.yaml, and every other
-  # setting is still adopted unchanged from the live repo via LateInitialize.
+  # Managed (Observe/Create/Update). forProvider declares the discoverability
+  # metadata (description/topics), so the config is AUTHORITATIVE for it; the
+  # org-wide squash-only merge policy comes from the shared patch in
+  # kustomization.yaml. Settings named in neither keep the value adopted from the
+  # live repo when it was first observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/gitops-tenant-template.yaml
+++ b/deploy/repositories/gitops-tenant-template.yaml
@@ -14,7 +14,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: gitops-tenant-template
     description: "Template for GitOps tenants on the devantler-tech platform — framework-agnostic CI/CD plumbing kept current via template-sync."

--- a/deploy/repositories/gitops-tenant-template.yaml
+++ b/deploy/repositories/gitops-tenant-template.yaml
@@ -8,8 +8,9 @@ spec:
   # Managed (Observe/Create/Update). forProvider declares the discoverability
   # metadata (description/topics), so the config is AUTHORITATIVE for it; the
   # org-wide squash-only merge policy comes from the shared patch in
-  # kustomization.yaml. Settings named in neither keep the value adopted from the
-  # live repo when it was first observed.
+  # kustomization.yaml. Settings in neither
+  # are unmanaged: nothing new is copied into the spec, and values adopted
+  # earlier stay.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/go-template.yaml
+++ b/deploy/repositories/go-template.yaml
@@ -14,7 +14,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: go-template
     description: "A simple Go template for new projects."

--- a/deploy/repositories/go-template.yaml
+++ b/deploy/repositories/go-template.yaml
@@ -5,11 +5,11 @@ metadata:
   annotations:
     crossplane.io/external-name: go-template
 spec:
-  # Managed (all except Delete). forProvider now declares the discoverability
-  # metadata (description/topics) so the config is AUTHORITATIVE for it
-  # (previously LateInitialized from live); the org-wide squash-only merge policy
-  # still comes from the shared patch in kustomization.yaml, and every other
-  # setting is still adopted unchanged from the live repo via LateInitialize.
+  # Managed (Observe/Create/Update). forProvider declares the discoverability
+  # metadata (description/topics), so the config is AUTHORITATIVE for it; the
+  # org-wide squash-only merge policy comes from the shared patch in
+  # kustomization.yaml. Settings named in neither keep the value adopted from the
+  # live repo when it was first observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/go-template.yaml
+++ b/deploy/repositories/go-template.yaml
@@ -8,8 +8,9 @@ spec:
   # Managed (Observe/Create/Update). forProvider declares the discoverability
   # metadata (description/topics), so the config is AUTHORITATIVE for it; the
   # org-wide squash-only merge policy comes from the shared patch in
-  # kustomization.yaml. Settings named in neither keep the value adopted from the
-  # live repo when it was first observed.
+  # kustomization.yaml. Settings in neither
+  # are unmanaged: nothing new is copied into the spec, and values adopted
+  # earlier stay.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/homebrew-tap.yaml
+++ b/deploy/repositories/homebrew-tap.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   # Managed (Observe/Create/Update). forProvider now declares the discoverability
   # metadata so the config is AUTHORITATIVE for it; the org-wide squash-only
-  # merge policy comes from the shared patch in kustomization.yaml. Settings named
-  # in neither keep the value adopted from the live repo when it was first
-  # observed.
+  # merge policy comes from the shared patch in kustomization.yaml. Settings in neither
+  # are unmanaged: nothing new is copied into the spec, and values adopted
+  # earlier stay.
   # NB: this is the one repo whose live description was empty — declaring it here
   # is a real (intentional) Update, not a no-op cutover like the other repos.
   managementPolicies:

--- a/deploy/repositories/homebrew-tap.yaml
+++ b/deploy/repositories/homebrew-tap.yaml
@@ -15,7 +15,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: homebrew-tap
     description: "Homebrew tap for devantler-tech CLIs (e.g. ksail)."

--- a/deploy/repositories/homebrew-tap.yaml
+++ b/deploy/repositories/homebrew-tap.yaml
@@ -5,10 +5,11 @@ metadata:
   annotations:
     crossplane.io/external-name: homebrew-tap
 spec:
-  # Managed (all except Delete). forProvider now declares the discoverability
+  # Managed (Observe/Create/Update). forProvider now declares the discoverability
   # metadata so the config is AUTHORITATIVE for it; the org-wide squash-only
-  # merge policy still comes from the shared patch in kustomization.yaml, and
-  # every other setting is still adopted unchanged via LateInitialize.
+  # merge policy comes from the shared patch in kustomization.yaml. Settings named
+  # in neither keep the value adopted from the live repo when it was first
+  # observed.
   # NB: this is the one repo whose live description was empty — declaring it here
   # is a real (intentional) Update, not a no-op cutover like the other repos.
   managementPolicies:

--- a/deploy/repositories/ksail.yaml
+++ b/deploy/repositories/ksail.yaml
@@ -7,11 +7,12 @@ metadata:
     # (owner comes from the ProviderConfig credentials).
     crossplane.io/external-name: ksail
 spec:
-  # Actively managed (everything except Delete). Merge policy from the shared
+  # Managed (Observe/Create/Update). Merge policy from the shared
   # patch; visibility pinned public + archived false so management can never
   # flip visibility or archive this repo. Discoverability metadata
   # (description/topics/homepageUrl) is declared so the config is AUTHORITATIVE
-  # for it (previously LateInitialized from live); LateInitialize adopts the rest.
+  # for it. Settings declared nowhere here keep the value adopted from the live
+  # repo when it was first observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/ksail.yaml
+++ b/deploy/repositories/ksail.yaml
@@ -16,7 +16,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: ksail
     visibility: public

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -90,3 +90,20 @@ patches:
       - op: add
         path: /spec/forProvider/hasDownloads
         value: false
+# ascoachingogvaner and wedding-app declare `visibility: private` while both live
+# repositories are public, and both host a deployed site. Which side is wrong is
+# the maintainer's call, tracked on #123. Until it is made, they stay on Observe:
+# Crossplane mirrors them read-only and writes nothing, so restoring the write
+# path org-wide cannot turn two live public sites private as a side effect.
+# Removing this patch is what enacts the decision, once the declared visibility
+# has been set to whatever the answer turns out to be.
+  - target:
+      group: repo.github.m.upbound.io
+      version: v1alpha1
+      kind: Repository
+      name: (ascoachingogvaner|wedding-app)
+    patch: |-
+      - op: replace
+        path: /spec/managementPolicies
+        value:
+          - Observe

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -1,14 +1,17 @@
 # One file per managed repository. Adoption is Observe-first: a repo starts with
 # managementPolicies: ["Observe"] (read-only — Crossplane mirrors live state into
 # status.atProvider and never writes), then forProvider is set and the policy
-# promoted to the full set EXCEPT Delete. Namespaced managed resources have no
-# deletionPolicy; omitting Delete is what guarantees Crossplane can never delete
-# a real GitHub repository. See devantler-tech/platform docs/github-management.md.
+# promoted to Observe/Create/Update by the shared patch below. Namespaced managed
+# resources have no deletionPolicy; omitting Delete is what guarantees Crossplane
+# can never delete a real GitHub repository. LateInitialize is omitted too: it
+# copies live-only values back into forProvider, and every field that lands there
+# is sent on every subsequent update PATCH. See devantler-tech/platform
+# docs/github-management.md.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # Actively managed (managementPolicies all-except-Delete). Every non-archived
-  # org repo; the shared merge-policy patch below applies to all of them.
+  # Actively managed (Observe/Create/Update). Every non-archived org repo; the
+  # shared policy patch below applies to all of them.
   - platform.yaml
   - ksail.yaml
   - maintenance.yaml
@@ -33,27 +36,36 @@ resources:
 # (auto-applies to every future repo):
 #  - squash-only merge policy (merge commits + rebase disabled; auto-merge,
 #    auto-delete head branches, always-suggest-updating-PR-branches enabled).
-#  - webCommitSignoffRequired: true — the org ENFORCES commit signoff and it
-#    can't be disabled per-repo, so the provider must always send true (else an
-#    update PATCH gets 422 "Commit signoff is enforced ... and cannot be
-#    disabled"). The 12 already-adopted repos had this true via LateInitialize;
-#    pinning it here makes every repo's update self-consistent and robust.
+#  - webCommitSignoffRequired: true, in initProvider — CREATE-ONLY. The org
+#    enforces commit signoff, and GitHub rejects the whole PATCH with 422
+#    "Commit signoff is enforced ... and cannot be disabled" whenever the field
+#    appears in a repository update, whatever value it carries. initProvider is
+#    applied at creation and never included in an update payload, so a new repo
+#    still gets the secure default while existing repos stay updatable.
 #  - hasDownloads: false — GitHub has removed the downloads feature and no
 #    longer returns the field, so status.atProvider never carries it. The
-#    Terraform provider still defaults it to true, so any repo whose spec picked
-#    that default up through LateInitialize holds a value the API can never
-#    report back. That is an unresolvable diff: the provider sees spec != live on
-#    every reconcile and issues an update PATCH forever. Those PATCHes are then
-#    rejected wholesale (422, on the commit-signoff field), so NO declared
-#    setting reaches GitHub for that repository — visibility included. Pinning
-#    the field to the value the API actually reflects is what stops the diff, and
-#    therefore what keeps the rest of this file enforceable.
+#    Terraform provider still defaults it to true, so a spec holding that default
+#    carries a value the API can never report back. That is an unresolvable diff:
+#    the provider sees spec != live on every reconcile and issues an update PATCH
+#    forever. Pinning the field to the value the API actually reflects is what
+#    stops the diff.
+# managementPolicies is replaced here rather than per repo, so the update
+# contract is stated once and every present and future repo inherits it.
 patches:
   - target:
       group: repo.github.m.upbound.io
       version: v1alpha1
       kind: Repository
     patch: |-
+      - op: replace
+        path: /spec/managementPolicies
+        value:
+          - Observe
+          - Create
+          - Update
+      - op: add
+        path: /spec/initProvider
+        value: {}
       - op: add
         path: /spec/forProvider/allowSquashMerge
         value: true
@@ -73,7 +85,7 @@ patches:
         path: /spec/forProvider/deleteBranchOnMerge
         value: true
       - op: add
-        path: /spec/forProvider/webCommitSignoffRequired
+        path: /spec/initProvider/webCommitSignoffRequired
         value: true
       - op: add
         path: /spec/forProvider/hasDownloads

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -57,12 +57,6 @@ patches:
       version: v1alpha1
       kind: Repository
     patch: |-
-      # initProvider must exist before a field can be added under it. Anything a
-      # repo needs at create time goes in the shared patch below, not in the repo
-      # file — this op replaces a per-repo initProvider block if one is added.
-      - op: add
-        path: /spec/initProvider
-        value: {}
       - op: add
         path: /spec/forProvider/allowSquashMerge
         value: true
@@ -82,8 +76,21 @@ patches:
         path: /spec/forProvider/deleteBranchOnMerge
         value: true
       - op: add
-        path: /spec/initProvider/webCommitSignoffRequired
-        value: true
-      - op: add
         path: /spec/forProvider/hasDownloads
         value: false
+  # A merge patch, not a JSON Patch op: it creates spec.initProvider when absent
+  # and merges into it when a repository declares its own create-only settings.
+  # A JSON Patch `add` on that path would replace the whole map and silently drop
+  # them.
+  - target:
+      group: repo.github.m.upbound.io
+      version: v1alpha1
+      kind: Repository
+    patch: |-
+      apiVersion: repo.github.m.upbound.io/v1alpha1
+      kind: Repository
+      metadata:
+        name: placeholder
+      spec:
+        initProvider:
+          webCommitSignoffRequired: true

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -49,20 +49,17 @@ resources:
 #    the provider sees spec != live on every reconcile and issues an update PATCH
 #    forever. Pinning the field to the value the API actually reflects is what
 #    stops the diff.
-# managementPolicies is replaced here rather than per repo, so the update
-# contract is stated once and every present and future repo inherits it.
+# managementPolicies stays per repo: adoption is Observe-first, and a shared
+# override would promote a repo to writing the moment it is added.
 patches:
   - target:
       group: repo.github.m.upbound.io
       version: v1alpha1
       kind: Repository
     patch: |-
-      - op: replace
-        path: /spec/managementPolicies
-        value:
-          - Observe
-          - Create
-          - Update
+      # initProvider must exist before a field can be added under it. Anything a
+      # repo needs at create time goes in the shared patch below, not in the repo
+      # file — this op replaces a per-repo initProvider block if one is added.
       - op: add
         path: /spec/initProvider
         value: {}
@@ -90,20 +87,3 @@ patches:
       - op: add
         path: /spec/forProvider/hasDownloads
         value: false
-# ascoachingogvaner and wedding-app declare `visibility: private` while both live
-# repositories are public, and both host a deployed site. Which side is wrong is
-# the maintainer's call, tracked on #123. Until it is made, they stay on Observe:
-# Crossplane mirrors them read-only and writes nothing, so restoring the write
-# path org-wide cannot turn two live public sites private as a side effect.
-# Removing this patch is what enacts the decision, once the declared visibility
-# has been set to whatever the answer turns out to be.
-  - target:
-      group: repo.github.m.upbound.io
-      version: v1alpha1
-      kind: Repository
-      name: (ascoachingogvaner|wedding-app)
-    patch: |-
-      - op: replace
-        path: /spec/managementPolicies
-        value:
-          - Observe

--- a/deploy/repositories/kyverno-policies.yaml
+++ b/deploy/repositories/kyverno-policies.yaml
@@ -19,7 +19,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: kyverno-policies
     description: "Shared Kyverno policy library for the devantler-tech platforms — the single source the platform and platform-template consume instead of vendoring per-repo copies."

--- a/deploy/repositories/maintenance.yaml
+++ b/deploy/repositories/maintenance.yaml
@@ -1,8 +1,9 @@
-# First repo brought under ACTIVE management (everything except Delete). The
+# First repo brought under ACTIVE management (Observe/Create/Update). The
 # merge policy (squash-only + auto-merge + auto-delete branches + suggest-update)
 # now comes from the shared patch in kustomization.yaml, so it is not repeated
 # here. `archived` is pinned false so management can never accidentally archive
-# the repo; `visibility` is intentionally left to LateInitialize (never hard-set).
+# the repo; `visibility` is intentionally never declared here, so management can
+# neither open nor close it.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: Repository
 metadata:

--- a/deploy/repositories/maintenance.yaml
+++ b/deploy/repositories/maintenance.yaml
@@ -14,7 +14,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     # Required once managementPolicies includes Create/Update (Observe-only
     # didn't enforce it); must equal the external-name / repo name.

--- a/deploy/repositories/platform-template.yaml
+++ b/deploy/repositories/platform-template.yaml
@@ -14,7 +14,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: platform-template
     description: "Opinionated, batteries-included Kubernetes platform (Flux GitOps + KSail + Talos) you instantiate from a template — fully automated bootstrap from GitHub Secrets. Derived from devantler-tech/platform."

--- a/deploy/repositories/platform-template.yaml
+++ b/deploy/repositories/platform-template.yaml
@@ -5,11 +5,11 @@ metadata:
   annotations:
     crossplane.io/external-name: platform-template
 spec:
-  # Managed (all except Delete). forProvider now declares the discoverability
-  # metadata (description/topics) so the config is AUTHORITATIVE for it
-  # (previously LateInitialized from live); the org-wide squash-only merge policy
-  # still comes from the shared patch in kustomization.yaml, and every other
-  # setting is still adopted unchanged from the live repo via LateInitialize.
+  # Managed (Observe/Create/Update). forProvider declares the discoverability
+  # metadata (description/topics), so the config is AUTHORITATIVE for it; the
+  # org-wide squash-only merge policy comes from the shared patch in
+  # kustomization.yaml. Settings named in neither keep the value adopted from the
+  # live repo when it was first observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/platform-template.yaml
+++ b/deploy/repositories/platform-template.yaml
@@ -8,8 +8,9 @@ spec:
   # Managed (Observe/Create/Update). forProvider declares the discoverability
   # metadata (description/topics), so the config is AUTHORITATIVE for it; the
   # org-wide squash-only merge policy comes from the shared patch in
-  # kustomization.yaml. Settings named in neither keep the value adopted from the
-  # live repo when it was first observed.
+  # kustomization.yaml. Settings in neither
+  # are unmanaged: nothing new is copied into the spec, and values adopted
+  # earlier stay.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/platform.yaml
+++ b/deploy/repositories/platform.yaml
@@ -7,12 +7,12 @@ metadata:
     # (owner comes from the ProviderConfig credentials).
     crossplane.io/external-name: platform
 spec:
-  # Actively managed (everything except Delete). The merge policy comes from the
+  # Managed (Observe/Create/Update). The merge policy comes from the
   # shared patch in kustomization.yaml; visibility is pinned public and archived
   # false explicitly so management can never flip visibility or archive this
   # repo. Discoverability metadata (description/topics/homepageUrl) is declared
-  # so the config is AUTHORITATIVE for it (previously LateInitialized from live);
-  # LateInitialize adopts every other setting unchanged.
+  # so the config is AUTHORITATIVE for it. Settings declared nowhere here keep the
+  # value adopted from the live repo when it was first observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/platform.yaml
+++ b/deploy/repositories/platform.yaml
@@ -17,7 +17,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: platform
     visibility: public

--- a/deploy/repositories/platform.yaml
+++ b/deploy/repositories/platform.yaml
@@ -11,8 +11,9 @@ spec:
   # shared patch in kustomization.yaml; visibility is pinned public and archived
   # false explicitly so management can never flip visibility or archive this
   # repo. Discoverability metadata (description/topics/homepageUrl) is declared
-  # so the config is AUTHORITATIVE for it. Settings declared nowhere here keep the
-  # value adopted from the live repo when it was first observed.
+  # so the config is AUTHORITATIVE for it. Settings in neither
+  # are unmanaged: nothing new is copied into the spec, and values adopted
+  # earlier stay.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/provider-upjet-unifi.yaml
+++ b/deploy/repositories/provider-upjet-unifi.yaml
@@ -14,7 +14,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: provider-upjet-unifi
     description: "Crossplane provider for Ubiquiti UniFi, generated with Upjet from ubiquiti-community/terraform-provider-unifi. Manage UniFi networks, WLANs, firewall, VPN/WireGuard, devices and settings as Kubernetes resources."

--- a/deploy/repositories/unifi.yaml
+++ b/deploy/repositories/unifi.yaml
@@ -14,7 +14,6 @@ spec:
     - Observe
     - Create
     - Update
-    - LateInitialize
   forProvider:
     name: unifi
     description: "Declarative configuration of my UniFi network (OpenTofu + filipowm/unifi), reconciled by tofu-controller as a platform tenant"

--- a/deploy/repositories/unifi.yaml
+++ b/deploy/repositories/unifi.yaml
@@ -5,11 +5,11 @@ metadata:
   annotations:
     crossplane.io/external-name: unifi
 spec:
-  # Managed (all except Delete). forProvider now declares the discoverability
-  # metadata (description/topics) so the config is AUTHORITATIVE for it
-  # (previously LateInitialized from live); the org-wide squash-only merge policy
-  # still comes from the shared patch in kustomization.yaml, and every other
-  # setting is still adopted unchanged from the live repo via LateInitialize.
+  # Managed (Observe/Create/Update). forProvider declares the discoverability
+  # metadata (description/topics), so the config is AUTHORITATIVE for it; the
+  # org-wide squash-only merge policy comes from the shared patch in
+  # kustomization.yaml. Settings named in neither keep the value adopted from the
+  # live repo when it was first observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/unifi.yaml
+++ b/deploy/repositories/unifi.yaml
@@ -8,8 +8,9 @@ spec:
   # Managed (Observe/Create/Update). forProvider declares the discoverability
   # metadata (description/topics), so the config is AUTHORITATIVE for it; the
   # org-wide squash-only merge policy comes from the shared patch in
-  # kustomization.yaml. Settings named in neither keep the value adopted from the
-  # live repo when it was first observed.
+  # kustomization.yaml. Settings in neither
+  # are unmanaged: nothing new is copied into the spec, and values adopted
+  # earlier stay.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/wedding-app.yaml
+++ b/deploy/repositories/wedding-app.yaml
@@ -5,16 +5,15 @@ metadata:
   annotations:
     crossplane.io/external-name: wedding-app
 spec:
-  # Actively managed (everything except Delete). Merge policy from the shared
-  # patch. PRIVATE repo: visibility is pinned private explicitly (never left to
-  # inference) so management can never expose it, and archived false so it can't
-  # be archived. description is declared so the config is AUTHORITATIVE for it
-  # (previously LateInitialized); LateInitialize adopts every other setting.
+  # Observe-only: this file declares `visibility: private` while the live
+  # repository is public and serving a site, so acting on the declaration would
+  # take the site off the public internet. Which side is wrong is the
+  # maintainer's call, tracked on devantler-tech/.github#123 — until it is made,
+  # Crossplane mirrors this repo read-only and writes nothing. Restoring
+  # Create/Update is what enacts the decision, once `visibility` below has been
+  # set to the answer.
   managementPolicies:
     - Observe
-    - Create
-    - Update
-    - LateInitialize
   forProvider:
     name: wedding-app
     visibility: private

--- a/tests/repository-update-policy.sh
+++ b/tests/repository-update-policy.sh
@@ -33,25 +33,25 @@ active_count="$(printf '%s\n' "$active_repositories" | grep -c . || true)"
   fail "active Repository set collapsed to $active_count entries"
 
 # LateInitialize copies live-only values into forProvider, and everything in
-# forProvider is sent on every update PATCH. Observe/Create/Update only.
+# forProvider is sent on every update PATCH. Delete would let a prune destroy a
+# real repository. Neither may appear; a repository parked on Observe alone is
+# allowed, because a resource that never writes cannot send a bad payload.
 unsafe_policies="$(
   yq -N '
     select(
       .kind == "Repository" and
       .spec.forProvider.archived != true and
       (
-        ((.spec.managementPolicies | length) != 3) or
-        (
-          (.spec.managementPolicies | contains(["Create", "Observe", "Update"])) !=
-          true
-        )
+        (.spec.managementPolicies | contains(["LateInitialize"])) or
+        (.spec.managementPolicies | contains(["Delete"])) or
+        ((.spec.managementPolicies | contains(["Observe"])) != true)
       )
     ) |
     .metadata.name
   ' "$render"
 )"
 [[ -z "$unsafe_policies" ]] ||
-  fail "active Repository resources must use only Observe/Create/Update: $unsafe_policies"
+  fail "active Repository resources must be Observe-based without LateInitialize or Delete: $unsafe_policies"
 
 # The org enforces commit signoff. GitHub rejects the entire PATCH with 422
 # whenever this field appears in a repository update, whatever value it carries,

--- a/tests/repository-update-policy.sh
+++ b/tests/repository-update-policy.sh
@@ -33,16 +33,21 @@ active_count="$(printf '%s\n' "$active_repositories" | grep -c . || true)"
   fail "active Repository set collapsed to $active_count entries"
 
 # LateInitialize copies live-only values into forProvider, and everything in
-# forProvider is sent on every update PATCH. Delete would let a prune destroy a
-# real repository. Neither may appear; a repository parked on Observe alone is
-# allowed, because a resource that never writes cannot send a bad payload.
+# forProvider is sent on every update PATCH, so LateInitialize is what turns a
+# live-only value into part of every future payload. The hazard is that pairing,
+# not LateInitialize itself: during Observe-first adoption a repository runs on
+# Observe+LateInitialize to mirror live state, sends nothing, and is safe. Delete
+# would let a prune destroy a real repository and is never allowed.
 unsafe_policies="$(
   yq -N '
     select(
       .kind == "Repository" and
       .spec.forProvider.archived != true and
       (
-        (.spec.managementPolicies | contains(["LateInitialize"])) or
+        (
+          (.spec.managementPolicies | contains(["LateInitialize"])) and
+          (.spec.managementPolicies | contains(["Update"]))
+        ) or
         (.spec.managementPolicies | contains(["Delete"])) or
         ((.spec.managementPolicies | contains(["Observe"])) != true)
       )
@@ -51,7 +56,7 @@ unsafe_policies="$(
   ' "$render"
 )"
 [[ -z "$unsafe_policies" ]] ||
-  fail "active Repository resources must be Observe-based without LateInitialize or Delete: $unsafe_policies"
+  fail "active Repository resources must not pair Update with LateInitialize, must exclude Delete, and must Observe: $unsafe_policies"
 
 # The org enforces commit signoff. GitHub rejects the entire PATCH with 422
 # whenever this field appears in a repository update, whatever value it carries,

--- a/tests/repository-update-policy.sh
+++ b/tests/repository-update-policy.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+render="$(mktemp)"
+trap 'rm -f "$render"' EXIT
+
+fail() {
+  echo "repository-update-policy test: $*" >&2
+  exit 1
+}
+
+for tool in kubectl yq; do
+  command -v "$tool" >/dev/null || fail "required tool '$tool' not found"
+done
+
+kubectl kustomize "$repo_root/deploy" >"$render" ||
+  fail "kubectl kustomize deploy/ failed"
+[[ -s "$render" ]] || fail "rendered output is empty"
+
+# Active (non-archived) repositories only. Archived repos live in
+# deploy/archived-repositories/, get no shared patch, and are read-only for
+# settings, so the update contract below does not apply to them.
+active_repositories="$(
+  yq -N '
+    select(.kind == "Repository" and .spec.forProvider.archived != true) |
+    .metadata.name
+  ' "$render"
+)"
+active_count="$(printf '%s\n' "$active_repositories" | grep -c . || true)"
+[[ "$active_count" -ge 10 ]] ||
+  fail "active Repository set collapsed to $active_count entries"
+
+# LateInitialize copies live-only values into forProvider, and everything in
+# forProvider is sent on every update PATCH. Observe/Create/Update only.
+unsafe_policies="$(
+  yq -N '
+    select(
+      .kind == "Repository" and
+      .spec.forProvider.archived != true and
+      (
+        ((.spec.managementPolicies | length) != 3) or
+        (
+          (.spec.managementPolicies | contains(["Create", "Observe", "Update"])) !=
+          true
+        )
+      )
+    ) |
+    .metadata.name
+  ' "$render"
+)"
+[[ -z "$unsafe_policies" ]] ||
+  fail "active Repository resources must use only Observe/Create/Update: $unsafe_policies"
+
+# The org enforces commit signoff. GitHub rejects the entire PATCH with 422
+# whenever this field appears in a repository update, whatever value it carries,
+# so it must never reach forProvider.
+update_payload_signoff="$(
+  yq -N '
+    select(
+      .kind == "Repository" and
+      .spec.forProvider.archived != true and
+      (.spec.forProvider | has("webCommitSignoffRequired"))
+    ) |
+    .metadata.name
+  ' "$render"
+)"
+[[ -z "$update_payload_signoff" ]] ||
+  fail "org-controlled signoff remains in forProvider: $update_payload_signoff"
+
+# Keeping it create-only is what preserves the secure default for new repos.
+missing_create_signoff="$(
+  yq -N '
+    select(
+      .kind == "Repository" and
+      .spec.forProvider.archived != true and
+      .spec.initProvider.webCommitSignoffRequired != true
+    ) |
+    .metadata.name
+  ' "$render"
+)"
+[[ -z "$missing_create_signoff" ]] ||
+  fail "create-only signoff is missing from initProvider: $missing_create_signoff"
+
+echo "repository-update-policy: OK — $active_count active repositories keep signoff create-only"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

None of the repository settings we declare in this repo could actually reach GitHub for any repo that
had something to apply. GitHub rejects an entire repository update when it mentions the commit-signoff
setting the organization already enforces, and our shared config put that setting into every update.

The visible cost: `agent-plugins` and `agent-skills` each declare a list of topics so people can find
them, and both still show no topics at all on GitHub. Two public products have been invisible to
topic-based browsing since the day those topics were declared.

## What

Applies the enforced signoff default only when a repository is **created**, so new repos still get it
while existing repos become updatable again. A new check runs in CI so this cannot silently come back.

Restoring the update path also means the config finally acts on what it declares — including two repos
that declare themselves private while being live and public with a deployed site
(`ascoachingogvaner`, `wedding-app`). Both are parked read-only here so that cannot happen as a side
effect; which side is wrong is your call, tracked on #123.

No repository loses the signoff protection, and deletion stays impossible as before.

Design and diagnosis come from #120; this is that change rebased onto current `main`, which it had
conflicted with since #125.

Fixes #112
