### PR TITLE
fix(repositories): stop declaring org-enforced signoff so updates can apply

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,10 @@ for the architecture, the GitHub App credential setup, and the Observe-first ado
   **excludes `Delete`** (observe/late-initialize), per platform's `docs/github-management.md`. Once
   adopted, an active `Repository` runs on `Observe`/`Create`/`Update` **without `LateInitialize`**:
   late-initialized values land in `forProvider`, and everything in `forProvider` is sent on every
-  subsequent update PATCH. An org-enforced create default such as `webCommitSignoffRequired` belongs
-  in `initProvider`, which Crossplane applies only at creation — GitHub rejects the whole PATCH with
-  422 whenever that field appears in an update. Verify
+  subsequent update PATCH. A field the org already enforces, such as `webCommitSignoffRequired`, is
+  declared in neither `forProvider` nor `initProvider`: GitHub rejects the whole PATCH with 422
+  whenever that field appears in an update, even carrying its own current value, and upjet feeds both
+  of those blocks into the payload. The org setting applies it to new repositories anyway. Verify
   the provider kind/field schema against the authoritative source
   ([crossplane-contrib/provider-upjet-github `package/crds/`](https://github.com/crossplane-contrib/provider-upjet-github)
   + `examples-generated/namespaced/`) — the CRs cannot be schema-validated locally (no cluster; CI

--- a/deploy/archived-repositories/kustomization.yaml
+++ b/deploy/archived-repositories/kustomization.yaml
@@ -1,7 +1,7 @@
 # Archived (or archival-bound) repositories, kept OUTSIDE ../repositories/ on
-# purpose: that kustomization's shared merge-policy patch (squash-only +
-# webCommitSignoffRequired) targets every Repository it renders, and an archived
-# repo is read-only for settings — each patched reconcile would 422 forever.
+# purpose: that kustomization's shared merge-policy patch (squash-only) targets
+# every Repository it renders, and an archived repo is read-only for settings —
+# each patched reconcile would 422 forever.
 # CRs here get NO shared patches; they carry only what an archived repo can hold.
 #
 # Lifecycle (two-phase, per devantler-tech/actions#425 AC3):

--- a/deploy/repositories/agent-plugins.yaml
+++ b/deploy/repositories/agent-plugins.yaml
@@ -9,10 +9,11 @@ metadata:
     # external-name, so the provider observes directly and reconciles cleanly.
     crossplane.io/external-name: agent-plugins
 spec:
-  # Squash-only merge policy + webCommitSignoffRequired come from the shared
-  # patch; description and topics are declared here so the config is
-  # AUTHORITATIVE for them. Settings declared nowhere here keep the value adopted
-  # from the live repo when it was first observed.
+  # The squash-only merge policy comes from the shared patch; commit signoff is
+  # declared nowhere and inherited from the organization. Description and topics
+  # are declared here so the config is AUTHORITATIVE for them. Settings declared
+  # nowhere here keep the value adopted from the live repo when it was first
+  # observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/agent-skills.yaml
+++ b/deploy/repositories/agent-skills.yaml
@@ -10,10 +10,11 @@ metadata:
     # reconciles cleanly.
     crossplane.io/external-name: agent-skills
 spec:
-  # Squash-only merge policy + webCommitSignoffRequired come from the shared
-  # patch; description and topics are declared here so the config is
-  # AUTHORITATIVE for them. Settings declared nowhere here keep the value adopted
-  # from the live repo when it was first observed.
+  # The squash-only merge policy comes from the shared patch; commit signoff is
+  # declared nowhere and inherited from the organization. Description and topics
+  # are declared here so the config is AUTHORITATIVE for them. Settings declared
+  # nowhere here keep the value adopted from the live repo when it was first
+  # observed.
   managementPolicies:
     - Observe
     - Create

--- a/deploy/repositories/aws.yaml
+++ b/deploy/repositories/aws.yaml
@@ -23,8 +23,9 @@ spec:
     description: "Declarative AWS infrastructure for the devantler-tech platform — Crossplane managed resources in deploy/, published as a cosign-signed OCI artifact and reconciled by the platform's aws tenant."
     visibility: public
     hasIssues: true
-    # Shared kustomization patch supplies the squash-only merge policy +
-    # webCommitSignoffRequired; nothing repo-specific needed here.
+    # Shared kustomization patch supplies the squash-only merge policy; commit
+    # signoff is inherited from the organization and declared nowhere. Nothing
+    # repo-specific needed here.
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -36,12 +36,15 @@ resources:
 # (auto-applies to every future repo):
 #  - squash-only merge policy (merge commits + rebase disabled; auto-merge,
 #    auto-delete head branches, always-suggest-updating-PR-branches enabled).
-#  - webCommitSignoffRequired: true, in initProvider — CREATE-ONLY. The org
-#    enforces commit signoff, and GitHub rejects the whole PATCH with 422
-#    "Commit signoff is enforced ... and cannot be disabled" whenever the field
-#    appears in a repository update, whatever value it carries. initProvider is
-#    applied at creation and never included in an update payload, so a new repo
-#    still gets the secure default while existing repos stay updatable.
+#  - webCommitSignoffRequired is declared NOWHERE, on purpose. The org enforces
+#    commit signoff, and GitHub rejects the whole PATCH with 422 "Commit signoff
+#    is enforced ... and cannot be disabled" whenever the field appears in a
+#    repository update — including when it carries its own current value of true.
+#    The Terraform provider omits the field from the payload only while it is
+#    left unconfigured, and upjet builds that configuration from forProvider and
+#    initProvider alike, so declaring it in either one reinstates the 422.
+#    Omitting it costs nothing: the org setting is what applies signoff to a new
+#    repository, and it is the same setting that makes the field unwritable.
 #  - hasDownloads: false — GitHub has removed the downloads feature and no
 #    longer returns the field, so status.atProvider never carries it. The
 #    Terraform provider still defaults it to true, so a spec holding that default
@@ -78,19 +81,3 @@ patches:
       - op: add
         path: /spec/forProvider/hasDownloads
         value: false
-  # A merge patch, not a JSON Patch op: it creates spec.initProvider when absent
-  # and merges into it when a repository declares its own create-only settings.
-  # A JSON Patch `add` on that path would replace the whole map and silently drop
-  # them.
-  - target:
-      group: repo.github.m.upbound.io
-      version: v1alpha1
-      kind: Repository
-    patch: |-
-      apiVersion: repo.github.m.upbound.io/v1alpha1
-      kind: Repository
-      metadata:
-        name: placeholder
-      spec:
-        initProvider:
-          webCommitSignoffRequired: true

--- a/deploy/repositories/kyverno-policies.yaml
+++ b/deploy/repositories/kyverno-policies.yaml
@@ -24,8 +24,9 @@ spec:
     description: "Shared Kyverno policy library for the devantler-tech platforms — the single source the platform and platform-template consume instead of vendoring per-repo copies."
     visibility: public
     hasIssues: true
-    # Shared kustomization patch supplies the squash-only merge policy +
-    # webCommitSignoffRequired; nothing repo-specific needed here.
+    # Shared kustomization patch supplies the squash-only merge policy; commit
+    # signoff is inherited from the organization and declared nowhere. Nothing
+    # repo-specific needed here.
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/provider-upjet-unifi.yaml
+++ b/deploy/repositories/provider-upjet-unifi.yaml
@@ -19,8 +19,9 @@ spec:
     description: "Crossplane provider for Ubiquiti UniFi, generated with Upjet from ubiquiti-community/terraform-provider-unifi. Manage UniFi networks, WLANs, firewall, VPN/WireGuard, devices and settings as Kubernetes resources."
     visibility: public
     hasIssues: true
-    # Shared kustomization patch supplies the squash-only merge policy +
-    # webCommitSignoffRequired; nothing repo-specific needed here.
+    # Shared kustomization patch supplies the squash-only merge policy; commit
+    # signoff is inherited from the organization and declared nowhere. Nothing
+    # repo-specific needed here.
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/tests/repository-update-policy.sh
+++ b/tests/repository-update-policy.sh
@@ -58,34 +58,28 @@ unsafe_policies="$(
 [[ -z "$unsafe_policies" ]] ||
   fail "active Repository resources must not pair Update with LateInitialize, must exclude Delete, and must Observe: $unsafe_policies"
 
-# The org enforces commit signoff. GitHub rejects the entire PATCH with 422
-# whenever this field appears in a repository update, whatever value it carries,
-# so it must never reach forProvider.
-update_payload_signoff="$(
+# The org enforces commit signoff, and GitHub rejects the entire PATCH with 422
+# whenever this field appears in a repository update — measured against the live
+# API, sending the field at its own current value of true still fails. The
+# Terraform provider only omits it from the payload when it is left unconfigured,
+# and upjet feeds BOTH forProvider and initProvider into that configuration, so
+# either one puts the field back into every update. It must appear in neither.
+# Nothing is lost by omitting it: the org setting is what applies signoff to a
+# new repository, which is the same policy that makes the field unwritable here.
+declared_signoff="$(
   yq -N '
     select(
       .kind == "Repository" and
       .spec.forProvider.archived != true and
-      (.spec.forProvider | has("webCommitSignoffRequired"))
+      (
+        (.spec.forProvider | has("webCommitSignoffRequired")) or
+        (.spec.initProvider | has("webCommitSignoffRequired"))
+      )
     ) |
     .metadata.name
   ' "$render"
 )"
-[[ -z "$update_payload_signoff" ]] ||
-  fail "org-controlled signoff remains in forProvider: $update_payload_signoff"
+[[ -z "$declared_signoff" ]] ||
+  fail "org-controlled signoff must not be declared in forProvider or initProvider: $declared_signoff"
 
-# Keeping it create-only is what preserves the secure default for new repos.
-missing_create_signoff="$(
-  yq -N '
-    select(
-      .kind == "Repository" and
-      .spec.forProvider.archived != true and
-      .spec.initProvider.webCommitSignoffRequired != true
-    ) |
-    .metadata.name
-  ' "$render"
-)"
-[[ -z "$missing_create_signoff" ]] ||
-  fail "create-only signoff is missing from initProvider: $missing_create_signoff"
-
-echo "repository-update-policy: OK — $active_count active repositories keep signoff create-only"
+echo "repository-update-policy: OK — $active_count active repositories leave signoff to the org"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Our declarative GitHub configuration has not been able to change **any** repository setting since it
was set up. Every update is rejected by GitHub, so declared settings that differ from the live repo
simply never take effect — two repos have had their declared topics sitting unapplied for weeks, and
the discovery surface they were written for has never existed.

The previous two attempts at this both narrowed the problem without fixing it. This one is based on a
direct measurement against the GitHub API rather than an assumption about how the setting behaves.

## What

Stops declaring the commit-signoff setting in our configuration at all.

GitHub refuses the whole update whenever that setting is mentioned, **even when we send the exact
value the repository already has**. Our organisation already enforces signoff on every repository —
including every new one — so declaring it bought us nothing and was the very thing blocking the write
path. Removing it lets everything else we declare actually apply, and loses no protection.

The existing safety check is updated to match: it now fails if the setting reappears anywhere, so
this cannot silently regress.

Fixes #112