### PR TITLE
refactor(deploy): rename gitops-tenant-template to platform-tenant-template

### DIFF
--- a/deploy/labels/kustomization.yaml
+++ b/deploy/labels/kustomization.yaml
@@ -32,7 +32,7 @@ resources:
   - unifi.yaml
   - aws.yaml
   - kyverno-policies.yaml
-  - gitops-tenant-template.yaml
+  - platform-tenant-template.yaml
   - platform-template.yaml
   - go-template.yaml
   - dotnet-template.yaml

--- a/deploy/labels/platform-tenant-template.yaml
+++ b/deploy/labels/platform-tenant-template.yaml
@@ -1,14 +1,14 @@
-# Issue labels for devantler-tech/gitops-tenant-template. The canonical org taxonomy (22 labels)
+# Issue labels for devantler-tech/platform-tenant-template. The canonical org taxonomy (22 labels)
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only gitops-tenant-template's repo-specific extras (the dependency/ecosystem labels
+# file adds only platform-tenant-template's repo-specific extras (the dependency/ecosystem labels
 # Dependabot/Renovate apply), declared so the authoritative set doesn't churn
 # against the bots. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
-  name: gitops-tenant-template
+  name: platform-tenant-template
   annotations:
-    crossplane.io/external-name: gitops-tenant-template
+    crossplane.io/external-name: platform-tenant-template
 spec:
   managementPolicies:
     - Observe
@@ -16,7 +16,7 @@ spec:
     - Update
     - LateInitialize
   forProvider:
-    repository: gitops-tenant-template
+    repository: platform-tenant-template
     label:
       - name: "dependencies"
         color: "0366d6"

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -21,7 +21,7 @@ resources:
   - unifi.yaml
   - aws.yaml
   - kyverno-policies.yaml
-  - gitops-tenant-template.yaml
+  - platform-tenant-template.yaml
   - platform-template.yaml
   - go-template.yaml
   - dotnet-template.yaml

--- a/deploy/repositories/platform-tenant-template.yaml
+++ b/deploy/repositories/platform-tenant-template.yaml
@@ -1,9 +1,9 @@
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: Repository
 metadata:
-  name: gitops-tenant-template
+  name: platform-tenant-template
   annotations:
-    crossplane.io/external-name: gitops-tenant-template
+    crossplane.io/external-name: platform-tenant-template
 spec:
   # Managed (Observe/Create/Update). forProvider declares the discoverability
   # metadata (description/topics), so the config is AUTHORITATIVE for it; the
@@ -16,8 +16,8 @@ spec:
     - Create
     - Update
   forProvider:
-    name: gitops-tenant-template
-    description: "Template for GitOps tenants on the devantler-tech platform — framework-agnostic CI/CD plumbing kept current via template-sync."
+    name: platform-tenant-template
+    description: "Template for platform tenants on the devantler-tech platform — framework-agnostic CI/CD plumbing kept current via template-sync."
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repository-permissions/kustomization.yaml
+++ b/deploy/repository-permissions/kustomization.yaml
@@ -33,7 +33,7 @@ resources:
   - agent-skills.yaml
   - agent-plugins.yaml
   - unifi.yaml
-  - gitops-tenant-template.yaml
+  - platform-tenant-template.yaml
   - platform-template.yaml
   - go-template.yaml
   - dotnet-template.yaml

--- a/deploy/repository-permissions/platform-tenant-template.yaml
+++ b/deploy/repository-permissions/platform-tenant-template.yaml
@@ -1,13 +1,13 @@
-# Actions permissions for devantler-tech/gitops-tenant-template — binds the org-wide
+# Actions permissions for devantler-tech/platform-tenant-template — binds the org-wide
 # shaPinningRequired policy (asserted once in kustomization.yaml) to this repo.
 # Observe+LateInitialize adopts the repo's live enabled/allowedActions so turning
 # on SHA-pinning never disturbs them. See ../README.md.
 apiVersion: actions.github.m.upbound.io/v1alpha1
 kind: RepositoryPermissions
 metadata:
-  name: gitops-tenant-template
+  name: platform-tenant-template
   annotations:
-    crossplane.io/external-name: gitops-tenant-template
+    crossplane.io/external-name: platform-tenant-template
 spec:
   managementPolicies:
     - Observe
@@ -15,7 +15,7 @@ spec:
     - Update
     - LateInitialize
   forProvider:
-    repository: gitops-tenant-template
+    repository: platform-tenant-template
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/team-repositories/grant-admins-on-platform-tenant-template.yaml
+++ b/deploy/team-repositories/grant-admins-on-platform-tenant-template.yaml
@@ -3,13 +3,13 @@
 apiVersion: team.github.m.upbound.io/v1alpha1
 kind: TeamRepository
 metadata:
-  name: admins-gitops-tenant-template
+  name: admins-platform-tenant-template
 spec:
   managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
   forProvider:
     teamIdRef:
       name: admins
-    repository: gitops-tenant-template
+    repository: platform-tenant-template
     permission: admin
   providerConfigRef:
     kind: ProviderConfig

--- a/deploy/team-repositories/grant-maintainers-on-platform-tenant-template.yaml
+++ b/deploy/team-repositories/grant-maintainers-on-platform-tenant-template.yaml
@@ -3,13 +3,13 @@
 apiVersion: team.github.m.upbound.io/v1alpha1
 kind: TeamRepository
 metadata:
-  name: maintainers-gitops-tenant-template
+  name: maintainers-platform-tenant-template
 spec:
   managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
   forProvider:
     teamIdRef:
       name: maintainers
-    repository: gitops-tenant-template
+    repository: platform-tenant-template
     permission: maintain
   providerConfigRef:
     kind: ProviderConfig

--- a/deploy/team-repositories/kustomization.yaml
+++ b/deploy/team-repositories/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
   - grant-maintainers-on-monorepo.yaml
   - grant-maintainers-on-platform.yaml
   # Created (grant did not exist yet).
-  - grant-maintainers-on-gitops-tenant-template.yaml
+  - grant-maintainers-on-platform-tenant-template.yaml
   - grant-maintainers-on-platform-template.yaml
   - grant-maintainers-on-unifi.yaml
   - grant-maintainers-on-homebrew-tap.yaml
@@ -32,7 +32,7 @@ resources:
   - grant-admins-on-aws.yaml
   - grant-admins-on-dotnet-template.yaml
   - grant-admins-on-fleet-gitops.yaml
-  - grant-admins-on-gitops-tenant-template.yaml
+  - grant-admins-on-platform-tenant-template.yaml
   - grant-admins-on-go-template.yaml
   - grant-admins-on-homebrew-tap.yaml
   - grant-admins-on-ksail.yaml

--- a/tests/admin-team-policy.sh
+++ b/tests/admin-team-policy.sh
@@ -56,7 +56,7 @@ repositories=(
   doggy-countdown
   dotnet-template
   fleet-gitops
-  gitops-tenant-template
+  platform-tenant-template
   go-template
   homebrew-tap
   ksail


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The `gitops-tenant-template` repository has been renamed to `platform-tenant-template` — GitOps is the technology it uses, not the product it is a tenant of. Maintainer direction, 2026-08-02.

**This one is not cosmetic.** This config is authoritative for the repository's name and description through Crossplane, so leaving it stale would let the next reconcile **rename the repository back**.

## What

Every managed resource for the repository moves: the `Repository` itself, its labels, its Actions permissions, and both team grants — plus the four kustomizations that list them and the admin-team policy test.

## Why replacing the managed resources is safe

Renaming `metadata.name` replaces a managed resource rather than editing it. That is safe here because **none of these declare `Delete` in `managementPolicies`** (verified per file: `[Observe, Create, Update]`, some with `LateInitialize`). The GitHub objects are therefore not deleted; the replacement resources adopt them via `crossplane.io/external-name`, which now matches the repository's real name.

The repository description is corrected in the same pass, for the same reason the repo was renamed.

## Verification

`tests/admin-team-policy.sh` passes, and it genuinely covers this: substituting a bogus repository name makes it fail with `expected 1 exact matches … got 0`, so the grant assertions are not vacuous.

Part of the rename: devantler-tech/monorepo#2627, devantler-tech/platform-tenant-template#126.