### PR TITLE
fix(release): prevent deploy changes from skipping publication

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
   merge_group:
 
 permissions: {}
@@ -21,7 +22,18 @@ jobs:
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: 🚦 Validate release contract
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
+            bash scripts/validate-release-contract.sh "$PR_TITLE"
 
       - name: 🧹 Validate deploy/ kustomize build
         # kubectl (with built-in kustomize) is preinstalled on the runner. A
@@ -37,6 +49,9 @@ jobs:
 
       - name: 🧪 Test repository update policy
         run: bash tests/repository-update-policy.sh
+
+      - name: 🧪 Test release contract
+        run: bash tests/release-contract.sh
 
   ci-required-checks:
     name: CI - Required Checks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
+          git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" |
             bash scripts/validate-release-contract.sh "$PR_TITLE"
 
       - name: 🧹 Validate deploy/ kustomize build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,9 @@ bash tests/repository-update-policy.sh  # active Repository update invariants
 bash tests/release-contract.sh          # deploy/ changes must trigger a release
 ```
 
-Those five commands are exactly what `ci.yaml` runs.
+Those five commands are the baseline checks that `ci.yaml` runs. Pull requests additionally pass
+their changed paths and title through `scripts/validate-release-contract.sh`; merge groups skip that
+event-specific check.
 
 `kubectl` (with built-in kustomize) is preinstalled on CI runners. A clean build proves the manifests
 are well-formed; the Crossplane CRDs themselves are applied/validated **on-cluster** (the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,9 +86,10 @@ kubectl kustomize deploy/ > /dev/null   # must build clean
 bash tests/admin-team-policy.sh         # Admins policy invariants
 bash tests/declarative-coverage.sh      # every repo declared in every rendered dimension
 bash tests/repository-update-policy.sh  # active Repository update invariants
+bash tests/release-contract.sh          # deploy/ changes must trigger a release
 ```
 
-Those four commands are exactly what `ci.yaml` runs.
+Those five commands are exactly what `ci.yaml` runs.
 
 `kubectl` (with built-in kustomize) is preinstalled on CI runners. A clean build proves the manifests
 are well-formed; the Crossplane CRDs themselves are applied/validated **on-cluster** (the

--- a/scripts/validate-release-contract.sh
+++ b/scripts/validate-release-contract.sh
@@ -12,7 +12,7 @@ deploy_changed=false
   exit 1
 }
 
-while IFS= read -r path; do
+while IFS= read -r -d '' path; do
   if [[ "$path" == deploy/* ]]; then
     deploy_changed=true
   fi

--- a/scripts/validate-release-contract.sh
+++ b/scripts/validate-release-contract.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+title="${1:-}"
+release_title='^(feat|fix|perf|revert)(\([[:alnum:]_.-]+\))?!?: .+'
+breaking_title='^[a-z]+(\([[:alnum:]_.-]+\))?!: .+'
+deploy_changed=false
+
+[[ -n "$title" ]] || {
+  echo "release-contract: pull-request title is required" >&2
+  exit 1
+}
+
+while IFS= read -r path; do
+  if [[ "$path" == deploy/* ]]; then
+    deploy_changed=true
+  fi
+done
+
+if [[ "$deploy_changed" == false ]]; then
+  echo "release-contract: OK — no deploy/ artifact change"
+  exit 0
+fi
+
+if [[ "$title" =~ $release_title || "$title" =~ $breaking_title ]]; then
+  echo "release-contract: OK — deploy/ change has a release-driving title"
+  exit 0
+fi
+
+echo "release-contract: deploy/ changes require a release-driving PR title (fix, feat, perf, revert, or a breaking ! type); got '$title'" >&2
+exit 1

--- a/tests/release-contract.sh
+++ b/tests/release-contract.sh
@@ -13,7 +13,7 @@ fail() {
 run_validator() {
   local title="$1"
   shift
-  printf '%s\n' "$@" | bash "$validator" "$title"
+  printf '%s\0' "$@" | bash "$validator" "$title"
 }
 
 expect_success() {
@@ -40,6 +40,10 @@ expect_failure \
 expect_failure \
   'docs(deploy): explain the platform tenant rename' \
   deploy/team-repositories/grant-admins-on-platform-tenant-template.yaml
+
+expect_failure \
+  'refactor(deploy): rename a path containing a newline' \
+  $'deploy/team-repositories/grant-admins-on-platform\ntenant-template.yaml'
 
 # Every title shape semantic-release maps to a release remains valid.
 expect_success \

--- a/tests/release-contract.sh
+++ b/tests/release-contract.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+validator="$repo_root/scripts/validate-release-contract.sh"
+
+fail() {
+  echo "release-contract test: $*" >&2
+  exit 1
+}
+
+run_validator() {
+  local title="$1"
+  shift
+  printf '%s\n' "$@" | bash "$validator" "$title"
+}
+
+expect_success() {
+  local title="$1"
+  shift
+  run_validator "$title" "$@" >/dev/null 2>&1 ||
+    fail "expected success for '$title' with paths: $*"
+}
+
+expect_failure() {
+  local title="$1"
+  shift
+  if run_validator "$title" "$@" >/dev/null 2>&1; then
+    fail "expected failure for '$title' with paths: $*"
+  fi
+}
+
+# A behavior-changing deploy edit must not disappear behind a no-bump squash
+# title. This reproduces the v1.21.4 -> main publication gap from issue #130.
+expect_failure \
+  'refactor(deploy): rename gitops-tenant-template to platform-tenant-template' \
+  deploy/team-repositories/grant-admins-on-platform-tenant-template.yaml
+
+expect_failure \
+  'docs(deploy): explain the platform tenant rename' \
+  deploy/team-repositories/grant-admins-on-platform-tenant-template.yaml
+
+# Every title shape semantic-release maps to a release remains valid.
+expect_success \
+  'fix(deploy): publish the platform tenant rename' \
+  deploy/team-repositories/grant-admins-on-platform-tenant-template.yaml
+expect_success \
+  'feat(deploy): add a repository policy' \
+  deploy/repositories/platform.yaml
+expect_success \
+  'perf(deploy): reduce reconciliation payloads' \
+  deploy/repositories/platform.yaml
+expect_success \
+  'revert: restore the previous repository policy' \
+  deploy/repositories/platform.yaml
+expect_success \
+  'refactor(deploy)!: replace repository ownership semantics' \
+  deploy/repositories/platform.yaml
+
+# Non-artifact changes keep their normal no-bump Conventional Commit types.
+expect_success \
+  'refactor(ci): simplify the validation workflow' \
+  .github/workflows/ci.yaml
+
+echo "release-contract: OK"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Root cause

PR #129 changed the published `deploy/` artifact but squash-merged as `refactor(deploy): ...`. semantic-release correctly treated that as a no-bump commit, so `main` advanced while the signed OCI artifact stayed at `v1.21.4`; production kept reconciling the stale `gitops-tenant-template` resources and Platform `apps` remained unhealthy.

## Change

- reject PRs that modify `deploy/` unless the squash title drives a release (`fix`, `feat`, `perf`, `revert`, or any breaking `!` type)
- rerun CI when a PR title is edited so a validated title cannot be changed after the check
- keep no-bump types valid for non-artifact changes
- document and test the release contract

The `fix(release):` title is deliberate: merging this PR publishes a patch release containing both the already-merged rename and this guard.

## TDD evidence

RED: `bash tests/release-contract.sh` failed because the missing validator could not accept a valid `fix(deploy):` case.

GREEN:

- `kubectl kustomize deploy/`
- `bash tests/admin-team-policy.sh`
- `bash tests/declarative-coverage.sh`
- `bash tests/repository-update-policy.sh`
- `bash tests/release-contract.sh`
- `bash -n scripts/validate-release-contract.sh tests/release-contract.sh`
- `actionlint .github/workflows/ci.yaml`
- `git diff --check`

## User evaluation

The exact title class that caused the outage (`refactor(deploy): ...` with a `deploy/` path) is refused. The same path with `fix(deploy): ...` is accepted, while a workflow-only `refactor(ci): ...` remains accepted.

Fixes #130