### PR TITLE
fix(deploy): preserve Actions release labels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,9 @@ jobs:
       - name: 🧪 Test declarative coverage
         run: bash tests/declarative-coverage.sh
 
+      - name: 🧪 Test declarative coverage failure handling
+        run: bash tests/declarative-coverage-fail-closed.sh
+
       - name: 🧪 Test repository update policy
         run: bash tests/repository-update-policy.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,11 +86,12 @@ structure; implementing PRs use `Fixes #N`.
 kubectl kustomize deploy/ > /dev/null   # must build clean
 bash tests/admin-team-policy.sh         # Admins policy invariants
 bash tests/declarative-coverage.sh      # every repo declared in every rendered dimension
+bash tests/declarative-coverage-fail-closed.sh # rendered-label reads fail closed
 bash tests/repository-update-policy.sh  # active Repository update invariants
 bash tests/release-contract.sh          # deploy/ changes must trigger a release
 ```
 
-Those five commands are the baseline checks that `ci.yaml` runs. Pull requests additionally pass
+Those six commands are the baseline checks that `ci.yaml` runs. Pull requests additionally pass
 their changed paths and title through `scripts/validate-release-contract.sh`; merge groups skip that
 event-specific check.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,8 @@ for the architecture, the GitHub App credential setup, and the Observe-first ado
   `github_actions`, Renovate extras) so the declared set is a superset — or you will delete labels in
   use. The canonical taxonomy lives once in [`deploy/labels/kustomization.yaml`](deploy/labels/)
   (a shared patch appended to every repo); each `deploy/labels/<repo>.yaml` adds **only** that repo's
-  ecosystem extras.
+  automation-specific extras, including dependency/ecosystem labels and lifecycle labels that an
+  automation requires to retain state.
 
 ## `deploy/` layout
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -27,8 +27,9 @@ out-of-band changes made in the GitHub UI.
   `maintain` to Maintainers and `admin` to Admins without claiming Delete.
 - `labels/` — one `IssueLabels` per managed repo. The canonical org label
   taxonomy lives once in `labels/kustomization.yaml` (a shared patch appended to
-  every repo); each `<repo>.yaml` adds only that repo's Dependabot/Renovate
-  ecosystem extras. Authoritative — out-of-band label drift is reverted. This is
+  every repo); each `<repo>.yaml` adds only that repo's automation-specific
+  extras, including dependency/ecosystem and lifecycle labels. Authoritative —
+  out-of-band label drift is reverted. This is
   the Crossplane replacement for the old EndBug/label-sync workflow.
 - `organization-rulesets/` — one `OrganizationRuleset` per file (org-wide branch/tag
   protection). 10 existing org rulesets are adopted **Observe-first** (read-only) + 1

--- a/deploy/labels/actions.yaml
+++ b/deploy/labels/actions.yaml
@@ -1,8 +1,9 @@
 # Issue labels for devantler-tech/actions. The canonical org taxonomy (22 labels)
 # is appended to every IssueLabels by the shared patch in kustomization.yaml; this
-# file adds only actions's repo-specific extras (the dependency/ecosystem labels
-# Dependabot/Renovate apply), declared so the authoritative set doesn't churn
-# against the bots. See ../README.md.
+# file adds only actions's repo-specific automation labels: dependency/ecosystem
+# markers used by Dependabot/Renovate and lifecycle markers used by Release
+# Please. Declaring them prevents authoritative reconciliation from deleting
+# state that those automations require. See ../README.md.
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: IssueLabels
 metadata:
@@ -22,6 +23,10 @@ spec:
         color: "0366d6"
       - name: "github_actions"
         color: "000000"
+      - name: "autorelease: pending"
+        color: "ededed"
+      - name: "autorelease: tagged"
+        color: "ededed"
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/labels/kustomization.yaml
+++ b/deploy/labels/kustomization.yaml
@@ -6,10 +6,11 @@
 # label set and reverts drift — exactly like the old action's `delete-other-labels:
 # true`, so the cutover is behaviour-preserving.
 #
-# One file per managed repo declares only that repo's repo-specific EXTRAS (the
-# Dependabot/Renovate ecosystem labels — `dependencies`, `go`, `docker`, … —
-# declared so the authoritative set doesn't churn against the bots that recreate
-# them). The shared patch below appends the CANONICAL org taxonomy (the 22 labels
+# One file per managed repo declares only that repo's automation-specific EXTRAS,
+# including dependency/ecosystem labels (`dependencies`, `go`, `docker`, …) and
+# lifecycle labels whose presence carries automation state. Declaring them keeps
+# the authoritative set from deleting state that those automations require. The
+# shared patch below appends the CANONICAL org taxonomy (the 22 labels
 # previously in `actions/.github/labels.yaml`) to every IssueLabels — this patch is
 # now the single source of truth for that taxonomy. Mirrors the org-wide settings
 # patch in ../repositories/kustomization.yaml.

--- a/tests/declarative-coverage-fail-closed.sh
+++ b/tests/declarative-coverage-fail-closed.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Negative control for the rendered Actions-label policy. A label reader may
+# emit partial output before failing; that output must never satisfy the policy.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+real_yq="$(command -v yq)"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  echo "declarative-coverage fail-closed test: $*" >&2
+  exit 1
+}
+
+mkdir "$work/bin"
+cat >"$work/bin/yq" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" == *'.spec.forProvider.label[].name'* ]]; then
+  printf '%s\n' 'autorelease: pending' 'autorelease: tagged'
+  exit 42
+fi
+
+exec "$REAL_YQ" "$@"
+EOF
+chmod +x "$work/bin/yq"
+
+if REAL_YQ="$real_yq" PATH="$work/bin:$PATH" \
+  bash "$repo_root/tests/declarative-coverage.sh" >"$work/stdout" 2>"$work/stderr"; then
+  fail "partial label output masked a yq read failure"
+fi
+
+grep -Fq "actions: failed to read rendered issue labels" "$work/stderr" || {
+  echo "declarative-coverage fail-closed test: unexpected failure:" >&2
+  cat "$work/stderr" >&2
+  exit 1
+}
+
+echo "declarative-coverage fail-closed: OK — partial yq output cannot pass"

--- a/tests/declarative-coverage.sh
+++ b/tests/declarative-coverage.sh
@@ -156,6 +156,21 @@ if [[ "$missing_count" -gt 0 ]]; then
   exit 1
 fi
 
+# Release Please identifies a merged release PR through these lifecycle labels.
+# IssueLabels is authoritative, so omitting either marker makes the reconciler
+# delete it before merge and causes Release Please to rescan historical commits.
+actions_labels="$(
+  yq -N '
+    select(.kind == "IssueLabels" and .spec.forProvider.repository == "actions")
+    | .spec.forProvider.label[].name
+  ' "$render" | grep -vE '^$|^null$|^---$' || true
+)"
+[[ -n "$actions_labels" ]] || fail "actions: no rendered issue labels"
+for required_label in "autorelease: pending" "autorelease: tagged"; do
+  printf '%s\n' "$actions_labels" | grep -Fxq "$required_label" ||
+    fail "actions: required Release Please label '$required_label' is undeclared"
+done
+
 echo "declarative-coverage: OK — $expected_count repositories across ${#labels[@]} rendered" \
   "dimensions ($exempt_count declared exemption(s))"
 

--- a/tests/declarative-coverage.sh
+++ b/tests/declarative-coverage.sh
@@ -159,11 +159,16 @@ fi
 # Release Please identifies a merged release PR through these lifecycle labels.
 # IssueLabels is authoritative, so omitting either marker makes the reconciler
 # delete it before merge and causes Release Please to rescan historical commits.
-actions_labels="$(
+if ! actions_labels_raw="$(
   yq -N '
     select(.kind == "IssueLabels" and .spec.forProvider.repository == "actions")
     | .spec.forProvider.label[].name
-  ' "$render" | grep -vE '^$|^null$|^---$' || true
+  ' "$render"
+)"; then
+  fail "actions: failed to read rendered issue labels"
+fi
+actions_labels="$(
+  printf '%s\n' "$actions_labels_raw" | grep -vE '^$|^null$|^---$' || true
 )"
 [[ -n "$actions_labels" ]] || fail "actions: no rendered issue labels"
 for required_label in "autorelease: pending" "autorelease: tagged"; do


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer.

## Motivation

The authoritative `IssueLabels` reconciler removed Release Please’s `autorelease: pending` label from Actions PR #892 twenty seconds after creation. Without that marker, Release Please could not recognize the merged v12.0.2 PR, rescanned 863 historical commits, and published v13.0.0.

## Change

- Declare `autorelease: pending` and `autorelease: tagged` as Actions-specific automation labels.
- Make rendered declarative coverage fail closed when either lifecycle label is absent.
- Preserve `yq` read failures even when partial output contains both required labels.
- Keep every canonical label-authoring instruction aligned with automation lifecycle extras.

## TDD evidence

- RED 1: `declarative-coverage test: actions: required Release Please label 'autorelease: pending' is undeclared`.
- GREEN 1: the rendered Actions policy contains both lifecycle labels.
- RED 2: a `yq` double emitted both labels, exited 42, and the old parser incorrectly passed.
- GREEN 2: the raw read status is checked before filtering; the same negative control now exits through the fail-closed path.
- All six repository validation commands, ShellCheck, bash syntax, actionlint, and `git diff --check` pass.

## Post-merge verification

Actions issue #894 remains open through deployment. After this repository publishes its signed config artifact and Flux applies it, verify the live Actions label definitions retain both lifecycle markers; then validate the next patch release is recognized and tagged without another historical rescan.

Part of devantler-tech/actions#894
Part of #56