### PR TITLE
fix(rulesets): correct the RepositoryRuleset external-name form

### DIFF
--- a/deploy/organization-rulesets/README.md
+++ b/deploy/organization-rulesets/README.md
@@ -15,8 +15,13 @@ Reconciled by the platform `github-config` tenant like the rest of `deploy/`.
   *visibility*, with zero behaviour change (the same flow `repositories/` and `teams/`
   used). `Delete` is omitted everywhere, so a CR/Flux prune can never delete a real
   ruleset.
-- **external-name = the import id.** `OrganizationRuleset` → the numeric ruleset id
-  (`gh api orgs/devantler-tech/rulesets`); `RepositoryRuleset` → `<repo>:<id>`.
+- **external-name = the numeric ruleset id**, for both Kinds — `OrganizationRuleset`
+  (`gh api orgs/devantler-tech/rulesets`) and `RepositoryRuleset`
+  (`gh api repos/devantler-tech/<repo>/rulesets`) alike. Terraform's
+  `<repo>:<ruleset_id>` is the **import** id, not the stored external-name: the provider
+  parses this annotation with `strconv.ParseInt`, so a `<repo>:`-prefixed value never
+  observes. (The composite `<team_id>:<repository>` form in `../team-repositories/` is a
+  different Kind and genuinely does take two parts — do not generalise it to rulesets.)
 - **forProvider is identity-only** on the Observe imports (`name`/`target`/
   `enforcement`). ⚠️ **Do not** promote an import past `Observe` without first
   backfilling its full `rules`/`conditions`/`bypassActors` from the observed

--- a/deploy/repository-rulesets/kustomization.yaml
+++ b/deploy/repository-rulesets/kustomization.yaml
@@ -1,5 +1,6 @@
 # `RepositoryRuleset` resources — one per file, named `<verb>-on-<repo>.yaml`, each a
-# repo-scoped rule adopted Observe-first (read-only). external-name = `<repo>:<id>`. See
+# repo-scoped rule adopted Observe-first (read-only). external-name = the bare numeric
+# ruleset id (a `<repo>:`-prefixed value fails the provider's ParseInt). See
 # ../organization-rulesets/README.md for the shared adoption convention and the provider
 # importability matrix. Included by ../kustomization.yaml.
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Two places that tell you how to declare a repository ruleset give a value the provider cannot
accept. Anyone following them writes a manifest that silently never picks up the live ruleset — no
error, it just quietly does nothing. The one ruleset already declared here worked around this and
carries the correction in its own comment, so today the working example and the instructions
disagree.

This is about to bite: the next ruleset to be added is the CLA gate on world-at-ruin
(devantler-tech/.github#107).

## What

Corrects both instructions to match what actually works, and records why the wrong form looks
plausible — the neighbouring team-repository grants really do use a two-part value, but they are a
different resource type.

Verified against production: the existing ruleset observes as expected using the corrected form.
