### PR TITLE
feat(rulesets): require the CLA gate check on world-at-ruin

### DIFF
--- a/deploy/repository-rulesets/README.md
+++ b/deploy/repository-rulesets/README.md
@@ -17,4 +17,10 @@ observes.
 
 | File | Repo | Ruleset | Policy |
 |---|---|---|---|
+| `require-cla-gate-on-world-at-ruin.yaml` | `world-at-ruin` | Require CLA gate | Managed (net-new; Observe + Create + Update + LateInitialize) |
 | `require-merge-queue-on-platform.yaml` | `platform` | Require merge queue | Observe (read-only import) |
+
+Most files here are Observe-first imports of a ruleset created out of band, so they carry a
+numeric `crossplane.io/external-name`. A **net-new** ruleset is the exception: it has no
+external-name and is managed (never `Delete`), so Crossplane creates it on first reconcile.
+`../organization-rulesets/protect-release-tags.yaml` is the org-level precedent for that shape.

--- a/deploy/repository-rulesets/kustomization.yaml
+++ b/deploy/repository-rulesets/kustomization.yaml
@@ -6,4 +6,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - require-cla-gate-on-world-at-ruin.yaml
   - require-merge-queue-on-platform.yaml

--- a/deploy/repository-rulesets/require-cla-gate-on-world-at-ruin.yaml
+++ b/deploy/repository-rulesets/require-cla-gate-on-world-at-ruin.yaml
@@ -1,0 +1,56 @@
+# Require the `CLA gate` check on world-at-ruin's default branch.
+#
+# world-at-ruin accepts outside contributions, and its `CLA gate` check (job
+# `cla-check` in that repo's .github/workflows/cla.yaml) fails red until an
+# external author has signed CLA.md. The check ran, but nothing *required* it:
+# every ruleset on the repo is organization-sourced, and the org's "Require
+# status checks to pass" ruleset requires exactly one context (`CI - Required
+# Checks`) for every repo — so adding `CLA gate` there would impose it on the
+# repos that have no CLA workflow at all. A repo-scoped ruleset is the only
+# place the requirement can be expressed without that spillover.
+#
+# The context to require is `CLA gate` — the JOB name. The workflow is named
+# `CLA`, so the workflow name is NOT the check context; requiring it would
+# block every PR on a check that never reports.
+#
+# Unlike the Observe-first imports in this directory (and like
+# ../organization-rulesets/protect-release-tags.yaml, the other net-new managed
+# ruleset), this has NO external-name and is managed Observe + Create + Update +
+# LateInitialize — never Delete — so Crossplane CREATES it on first reconcile
+# and then keeps it in sync.
+#
+# strictRequiredStatusChecksPolicy is false on purpose: `true` additionally
+# demands the branch be up to date with the base before merging, which forces a
+# rebase round-trip on every PR. This rule is here to close a legal gate, not to
+# change how anyone merges — the everyday path is exactly as easy as before.
+#
+# No bypassActors, consistent with the org's other protective rulesets. Trusted
+# authors are unaffected in practice: `CLA gate` passes instantly for them via
+# the workflow's allowlist.
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: RepositoryRuleset
+metadata:
+  name: world-at-ruin-require-cla-gate
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    repository: world-at-ruin
+    name: Require CLA gate
+    target: branch
+    enforcement: active
+    conditions:
+      - refName:
+          - include: ["~DEFAULT_BRANCH"]
+            exclude: []
+    rules:
+      - requiredStatusChecks:
+          - requiredCheck:
+              - context: CLA gate
+            strictRequiredStatusChecksPolicy: false
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`world-at-ruin` takes outside contributions, and its `CLA gate` check blocks a PR until the author has signed the CLA. The check ran — but nothing *required* it, so an unsigned external PR could still be merged. The legal gate depended on reviewer discipline rather than being enforced.

## What

Adds a repo-scoped ruleset making `CLA gate` a required check on world-at-ruin's default branch, declared in the same GitOps directory as the org's other rulesets.

Why repo-scoped rather than the existing org rule: every ruleset on world-at-ruin today is organization-sourced, and the org's required-checks ruleset carries a single context for **all** repos — so adding `CLA gate` there would impose it on repos that have no CLA workflow and block them outright. Repo-scoped is the only place it fits.

**Security floor gained:** an unsigned external contribution can no longer be merged, in any circumstance, rather than only when a reviewer notices.
**Everyday cost:** none. `CLA gate` passes instantly for trusted authors via the workflow's allowlist, and the rule deliberately does *not* set the strict "branch must be up to date" policy, so no PR gains a rebase round-trip.

Reversible: delete the file. The resource is managed without `Delete`, matching the org-level precedent.

Part of #107
---

**Deliberately `Part of`, not `Fixes`.** This repo's own `AGENTS.md` notes that a clean `kubectl kustomize` build proves the manifests are well-formed but that the Crossplane CRs are validated **on-cluster**, not in CI — so merging this is what puts the ruleset in front of the provider, and the acceptance criterion ("an external PR with a red `CLA gate` cannot be merged") is only observable afterwards. platform#2922 is open right now for exactly the opposite mistake: a config that validated green, was read by its consumer, and never reached the running system. #107 stays open until the live read-back confirms the ruleset exists and requires `CLA gate`.
