### PR TITLE
fix(repositories): declare org-enforced signoff so updates can apply

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,11 +43,16 @@ for the architecture, the GitHub App credential setup, and the Observe-first ado
   `crossplane.io/external-name` annotation to the live name and use a management policy that
   **excludes `Delete`** (observe/late-initialize), per platform's `docs/github-management.md`. Once
   adopted, an active `Repository` runs on `Observe`/`Create`/`Update` **without `LateInitialize`**:
-  late-initialized values land in `forProvider`, and everything in `forProvider` is sent on every
-  subsequent update PATCH. A field the org already enforces, such as `webCommitSignoffRequired`, is
-  declared in neither `forProvider` nor `initProvider`: GitHub rejects the whole PATCH with 422
-  whenever that field appears in an update, even carrying its own current value, and upjet feeds both
-  of those blocks into the payload. The org setting applies it to new repositories anyway. Verify
+  late-initialized values land in `forProvider` and are then part of the resource's declared state. A
+  field the org already enforces, such as `webCommitSignoffRequired`, must be **declared in
+  `forProvider` at the value the org enforces** — never left unconfigured and never seeded through
+  the create-only `initProvider`. upjet builds the Terraform configuration from `forProvider`, an
+  absent optional bool takes the provider's zero value of `false`, and `false` against a live `true`
+  is a permanent diff, so every update PATCH carries `web_commit_signoff_required: false` and GitHub
+  rejects the whole request with 422 "Commit signoff is enforced ... and cannot be disabled". The
+  error names disabling, not presence: declaring the live value leaves nothing to diff, so Terraform
+  omits the field from the payload and the update applies. `tests/repository-update-policy.sh` pins
+  this. Verify
   the provider kind/field schema against the authoritative source
   ([crossplane-contrib/provider-upjet-github `package/crds/`](https://github.com/crossplane-contrib/provider-upjet-github)
   + `examples-generated/namespaced/`) — the CRs cannot be schema-validated locally (no cluster; CI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,9 @@ for the architecture, the GitHub App credential setup, and the Observe-first ado
   `crossplane.io/external-name` annotation to the live name and use a management policy that
   **excludes `Delete`** (observe/late-initialize), per platform's `docs/github-management.md`. Once
   adopted, an active `Repository` runs on `Observe`/`Create`/`Update` **without `LateInitialize`**:
-  late-initialized values land in `forProvider` and are then part of the resource's declared state. A
+  the values late-initialized *during adoption* stay in `forProvider` as provider-owned state, and
+  once `LateInitialize` is gone **no newly observed field is ever copied in again** — so a resource
+  adopted without a given field never acquires it, and nothing but the config can supply it. A
   field the org already enforces, such as `webCommitSignoffRequired`, must be **declared in
   `forProvider` at the value the org enforces** — never left unconfigured and never seeded through
   the create-only `initProvider`. upjet builds the Terraform configuration from `forProvider`, an

--- a/deploy/archived-repositories/kustomization.yaml
+++ b/deploy/archived-repositories/kustomization.yaml
@@ -1,7 +1,7 @@
 # Archived (or archival-bound) repositories, kept OUTSIDE ../repositories/ on
-# purpose: that kustomization's shared merge-policy patch (squash-only) targets
-# every Repository it renders, and an archived repo is read-only for settings —
-# each patched reconcile would 422 forever.
+# purpose: that kustomization's shared merge-policy patch (squash-only +
+# webCommitSignoffRequired) targets every Repository it renders, and an archived
+# repo is read-only for settings — each patched reconcile would 422 forever.
 # CRs here get NO shared patches; they carry only what an archived repo can hold.
 #
 # Lifecycle (two-phase, per devantler-tech/actions#425 AC3):

--- a/deploy/repositories/agent-plugins.yaml
+++ b/deploy/repositories/agent-plugins.yaml
@@ -9,8 +9,8 @@ metadata:
     # external-name, so the provider observes directly and reconciles cleanly.
     crossplane.io/external-name: agent-plugins
 spec:
-  # The squash-only merge policy comes from the shared patch; commit signoff is
-  # declared nowhere and inherited from the organization. Description and topics
+  # The squash-only merge policy and the org-enforced commit signoff come from
+  # the shared patch. Description and topics
   # are declared here so the config is AUTHORITATIVE for them. Settings declared
   # nowhere here keep the value adopted from the live repo when it was first
   # observed.

--- a/deploy/repositories/agent-skills.yaml
+++ b/deploy/repositories/agent-skills.yaml
@@ -10,8 +10,8 @@ metadata:
     # reconciles cleanly.
     crossplane.io/external-name: agent-skills
 spec:
-  # The squash-only merge policy comes from the shared patch; commit signoff is
-  # declared nowhere and inherited from the organization. Description and topics
+  # The squash-only merge policy and the org-enforced commit signoff come from
+  # the shared patch. Description and topics
   # are declared here so the config is AUTHORITATIVE for them. Settings declared
   # nowhere here keep the value adopted from the live repo when it was first
   # observed.

--- a/deploy/repositories/aws.yaml
+++ b/deploy/repositories/aws.yaml
@@ -23,9 +23,8 @@ spec:
     description: "Declarative AWS infrastructure for the devantler-tech platform — Crossplane managed resources in deploy/, published as a cosign-signed OCI artifact and reconciled by the platform's aws tenant."
     visibility: public
     hasIssues: true
-    # Shared kustomization patch supplies the squash-only merge policy; commit
-    # signoff is inherited from the organization and declared nowhere. Nothing
-    # repo-specific needed here.
+    # Shared kustomization patch supplies the squash-only merge policy and the
+    # org-enforced commit signoff; nothing repo-specific needed here.
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/kustomization.yaml
+++ b/deploy/repositories/kustomization.yaml
@@ -36,15 +36,19 @@ resources:
 # (auto-applies to every future repo):
 #  - squash-only merge policy (merge commits + rebase disabled; auto-merge,
 #    auto-delete head branches, always-suggest-updating-PR-branches enabled).
-#  - webCommitSignoffRequired is declared NOWHERE, on purpose. The org enforces
-#    commit signoff, and GitHub rejects the whole PATCH with 422 "Commit signoff
-#    is enforced ... and cannot be disabled" whenever the field appears in a
-#    repository update — including when it carries its own current value of true.
-#    The Terraform provider omits the field from the payload only while it is
-#    left unconfigured, and upjet builds that configuration from forProvider and
-#    initProvider alike, so declaring it in either one reinstates the 422.
-#    Omitting it costs nothing: the org setting is what applies signoff to a new
-#    repository, and it is the same setting that makes the field unwritable.
+#  - webCommitSignoffRequired: true — declared precisely BECAUSE the org enforces
+#    it. Leaving the field unconfigured is what breaks updates, not declaring it.
+#    upjet builds the Terraform configuration from forProvider, an absent optional
+#    bool takes the provider's zero value of false, and false against a live true
+#    is a permanent diff — so every update PATCH carries
+#    web_commit_signoff_required: false and GitHub rejects the whole request with
+#    422 "Commit signoff is enforced ... and cannot be disabled". The error names
+#    disabling, not presence. Declaring the live value leaves nothing to diff, so
+#    Terraform omits the field from the payload and the rest of the update
+#    applies. Measured: with this line present, nine write-enabled repositories
+#    completed update PATCHes at 2026-07-27T04:34:5xZ; two minutes after it was
+#    removed the same repositories began failing on that 422, and seven were
+#    still failing on 2026-08-06. See #112.
 #  - hasDownloads: false — GitHub has removed the downloads feature and no
 #    longer returns the field, so status.atProvider never carries it. The
 #    Terraform provider still defaults it to true, so a spec holding that default
@@ -77,6 +81,9 @@ patches:
         value: true
       - op: add
         path: /spec/forProvider/deleteBranchOnMerge
+        value: true
+      - op: add
+        path: /spec/forProvider/webCommitSignoffRequired
         value: true
       - op: add
         path: /spec/forProvider/hasDownloads

--- a/deploy/repositories/kyverno-policies.yaml
+++ b/deploy/repositories/kyverno-policies.yaml
@@ -24,9 +24,8 @@ spec:
     description: "Shared Kyverno policy library for the devantler-tech platforms — the single source the platform and platform-template consume instead of vendoring per-repo copies."
     visibility: public
     hasIssues: true
-    # Shared kustomization patch supplies the squash-only merge policy; commit
-    # signoff is inherited from the organization and declared nowhere. Nothing
-    # repo-specific needed here.
+    # Shared kustomization patch supplies the squash-only merge policy and the
+    # org-enforced commit signoff; nothing repo-specific needed here.
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/deploy/repositories/platform-tenant-template.yaml
+++ b/deploy/repositories/platform-tenant-template.yaml
@@ -20,8 +20,8 @@ spec:
     # Pinned because this resource carries no adopted values: it is the one
     # active repository whose spec holds nothing beyond what the config declares,
     # so an update cannot fall back on a previously observed visibility the way
-    # every other repository here can. Declaring the live value keeps restoring
-    # the write path (#112) from being able to change it.
+    # every other repository here can. Declaring the live value is what makes
+    # restoring the write path (#112) unable to change it.
     visibility: public
     description: "Template for platform tenants on the devantler-tech platform — framework-agnostic CI/CD plumbing kept current via template-sync."
   providerConfigRef:

--- a/deploy/repositories/platform-tenant-template.yaml
+++ b/deploy/repositories/platform-tenant-template.yaml
@@ -17,6 +17,12 @@ spec:
     - Update
   forProvider:
     name: platform-tenant-template
+    # Pinned because this resource carries no adopted values: it is the one
+    # active repository whose spec holds nothing beyond what the config declares,
+    # so an update cannot fall back on a previously observed visibility the way
+    # every other repository here can. Declaring the live value keeps restoring
+    # the write path (#112) from being able to change it.
+    visibility: public
     description: "Template for platform tenants on the devantler-tech platform — framework-agnostic CI/CD plumbing kept current via template-sync."
   providerConfigRef:
     kind: ProviderConfig

--- a/deploy/repositories/provider-upjet-unifi.yaml
+++ b/deploy/repositories/provider-upjet-unifi.yaml
@@ -19,9 +19,8 @@ spec:
     description: "Crossplane provider for Ubiquiti UniFi, generated with Upjet from ubiquiti-community/terraform-provider-unifi. Manage UniFi networks, WLANs, firewall, VPN/WireGuard, devices and settings as Kubernetes resources."
     visibility: public
     hasIssues: true
-    # Shared kustomization patch supplies the squash-only merge policy; commit
-    # signoff is inherited from the organization and declared nowhere. Nothing
-    # repo-specific needed here.
+    # Shared kustomization patch supplies the squash-only merge policy and the
+    # org-enforced commit signoff; nothing repo-specific needed here.
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/tests/repository-update-policy.sh
+++ b/tests/repository-update-policy.sh
@@ -74,7 +74,7 @@ unsafe_policies="$(
 # write-enabled repositories recorded LastAsyncOperation=Success — completed
 # update PATCHes. Two minutes after the declaration was removed the same
 # repositories began recording AsyncUpdateFailure carrying that 422, and seven
-# were still failing on 2026-08-06. See devantler-tech/.github#123.
+# were still failing on 2026-08-06. See devantler-tech/.github#112.
 #
 # initProvider is not a substitute: Crossplane applies it only at creation, so
 # forProvider stays unconfigured and the permanent diff above is unchanged.

--- a/tests/repository-update-policy.sh
+++ b/tests/repository-update-policy.sh
@@ -58,28 +58,50 @@ unsafe_policies="$(
 [[ -z "$unsafe_policies" ]] ||
   fail "active Repository resources must not pair Update with LateInitialize, must exclude Delete, and must Observe: $unsafe_policies"
 
-# The org enforces commit signoff, and GitHub rejects the entire PATCH with 422
-# whenever this field appears in a repository update — measured against the live
-# API, sending the field at its own current value of true still fails. The
-# Terraform provider only omits it from the payload when it is left unconfigured,
-# and upjet feeds BOTH forProvider and initProvider into that configuration, so
-# either one puts the field back into every update. It must appear in neither.
-# Nothing is lost by omitting it: the org setting is what applies signoff to a
-# new repository, which is the same policy that makes the field unwritable here.
-declared_signoff="$(
+# Every active repository must declare webCommitSignoffRequired: true in
+# forProvider, because the org enforces commit signoff and live is therefore
+# always true. Leaving the field unconfigured does NOT keep it out of the update
+# payload: upjet builds the Terraform configuration from forProvider, an absent
+# optional bool takes the provider's zero value of false, and false against a
+# live true is a permanent diff — so every update PATCH carries
+# web_commit_signoff_required: false and GitHub rejects the whole request with
+# 422 "Commit signoff is enforced by the organization and cannot be disabled".
+# Declaring the live value leaves nothing to diff, so Terraform omits the field
+# from the payload and the rest of the update applies.
+#
+# The 422 names disabling, not presence, and the cluster agrees: at
+# 2026-07-27T04:34:5xZ, with this field declared by the shared patch, nine
+# write-enabled repositories recorded LastAsyncOperation=Success — completed
+# update PATCHes. Two minutes after the declaration was removed the same
+# repositories began recording AsyncUpdateFailure carrying that 422, and seven
+# were still failing on 2026-08-06. See devantler-tech/.github#123.
+#
+# initProvider is not a substitute: Crossplane applies it only at creation, so
+# forProvider stays unconfigured and the permanent diff above is unchanged.
+missing_signoff="$(
   yq -N '
     select(
       .kind == "Repository" and
       .spec.forProvider.archived != true and
-      (
-        (.spec.forProvider | has("webCommitSignoffRequired")) or
-        (.spec.initProvider | has("webCommitSignoffRequired"))
-      )
+      .spec.forProvider.webCommitSignoffRequired != true
     ) |
     .metadata.name
   ' "$render"
 )"
-[[ -z "$declared_signoff" ]] ||
-  fail "org-controlled signoff must not be declared in forProvider or initProvider: $declared_signoff"
+[[ -z "$missing_signoff" ]] ||
+  fail "active Repository resources must declare forProvider.webCommitSignoffRequired: true so updates carry no disabling value: $missing_signoff"
 
-echo "repository-update-policy: OK — $active_count active repositories leave signoff to the org"
+seeded_signoff="$(
+  yq -N '
+    select(
+      .kind == "Repository" and
+      .spec.forProvider.archived != true and
+      (.spec.initProvider | has("webCommitSignoffRequired"))
+    ) |
+    .metadata.name
+  ' "$render"
+)"
+[[ -z "$seeded_signoff" ]] ||
+  fail "signoff must be declared in forProvider, not the create-only initProvider: $seeded_signoff"
+
+echo "repository-update-policy: OK — $active_count active repositories declare org-enforced signoff"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Declarative repository configuration has not been reaching GitHub. Seven of the twenty managed repositories reject **every** settings update with a 422, so anything declared for them — description, topics, merge policy, visibility — silently never applies. The ten that still work do so only by accident of history, not because the config makes them work, which means the same failure reaches any newly-declared repository. That is how this surfaced: `doggy-countdown` was added and was broken from the moment it was created.

Two earlier attempts (#127, #128) closed the tracking issue and were reopened within minutes each time, because both were built on the same wrong explanation of the cause.

## What

Declares the signoff setting at the value the organization already enforces, instead of leaving it unset. Leaving it unset is what was generating the rejected update; declaring it removes the conflict, and the rest of the update then applies normally.

The live cluster records the switch at two-minute resolution: with the setting declared, nine repositories completed real updates; two minutes after it was removed, those same repositories started failing, and seven were still failing today.

One repository (`platform-tenant-template`) holds no previously-adopted settings, so restoring updates there could otherwise have changed its visibility — its current value is pinned explicitly so it cannot move.

The CI check that had locked in the wrong rule now enforces the correct one, so this cannot regress.

**Verification after merge:** the seven failing repositories should report a successful sync rather than the 422. That is a live read, recorded on the issue — this does not close on merge alone.

Fixes #112