### PR TITLE
ci: check declared repository settings against live GitHub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,12 @@ jobs:
       - name: 🧪 Test release contract
         run: bash tests/release-contract.sh
 
+      # The drift check itself reads live GitHub state and runs on a schedule
+      # (repository-drift-check.yaml); this only pins its comparison logic,
+      # against fixtures, so it stays offline and PR-safe.
+      - name: 🧪 Test repository drift check
+        run: bash tests/repository-drift.sh
+
   ci-required-checks:
     name: CI - Required Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/repository-drift-check.yaml
+++ b/.github/workflows/repository-drift-check.yaml
@@ -32,6 +32,9 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # The token defaults to this repository alone; the check reads every
+          # repository deploy/ declares, so it has to cover the whole owner.
+          owner: ${{ github.repository_owner }}
           # Least-privilege scope (zizmor github-app): the check only reads
           # repository settings, and the org has a private repository that the
           # workflow's own GITHUB_TOKEN cannot see.

--- a/.github/workflows/repository-drift-check.yaml
+++ b/.github/workflows/repository-drift-check.yaml
@@ -39,6 +39,10 @@ jobs:
       - name: 🎯 Resolve the repositories to read
         id: targets
         run: |
+          # Without pipefail a failed render still exits 0 through the pipe, and
+          # the emptiness guard below would be the only thing standing between
+          # that and a token scoped to nothing.
+          set -euo pipefail
           targets="$(
             kubectl kustomize deploy |
               yq -N '

--- a/.github/workflows/repository-drift-check.yaml
+++ b/.github/workflows/repository-drift-check.yaml
@@ -26,24 +26,42 @@ jobs:
     permissions:
       contents: read # checkout
     steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # The token has to reach every repository the check reads, and no more.
+      # Deriving the list from deploy/ — the same source the check itself reads
+      # — is what keeps those two in step; a hand-maintained list here would be
+      # one more declaration that can silently go stale, which is the very thing
+      # this workflow exists to catch.
+      - name: 🎯 Resolve the repositories to read
+        id: targets
+        run: |
+          targets="$(
+            kubectl kustomize deploy |
+              yq -N '
+                select(.kind == "Repository") |
+                (.metadata.annotations["crossplane.io/external-name"] // .metadata.name)
+              ' | paste -sd, -
+          )"
+          [ -n "$targets" ] || { echo "deploy/ declares no repositories" >&2; exit 1; }
+          echo "list=$targets" >>"$GITHUB_OUTPUT"
+
       - name: 🔑 Get GitHub App Token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          # The token defaults to this repository alone; the check reads every
-          # repository deploy/ declares, so it has to cover the whole owner.
+          # Least-privilege scope (zizmor github-app): metadata only, and only
+          # over the declared repositories. The workflow's own GITHUB_TOKEN
+          # cannot be used instead — it reaches this repository alone, and the
+          # org has a private repository it could not see either way.
           owner: ${{ github.repository_owner }}
-          # Least-privilege scope (zizmor github-app): the check only reads
-          # repository settings, and the org has a private repository that the
-          # workflow's own GITHUB_TOKEN cannot see.
+          repositories: ${{ steps.targets.outputs.list }}
           permission-metadata: read
-
-      - name: 📑 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
 
       - name: 🔍 Compare declared and live repository settings
         env:

--- a/.github/workflows/repository-drift-check.yaml
+++ b/.github/workflows/repository-drift-check.yaml
@@ -1,0 +1,48 @@
+name: 🔍 Repository drift check
+
+# Fails when a repository setting declared in deploy/ disagrees with the live
+# repository on GitHub.
+#
+# Cluster state cannot answer this on its own: a Repository managed resource
+# only issues an update PATCH when it has a pending diff, so one that writes
+# nothing — because it is Observe-only, or because its writes are rejected —
+# reports Synced=ReconcileSuccess indefinitely while its declaration goes
+# unapplied. Comparing the two ends directly is what catches that.
+#
+# This runs on a schedule rather than on pull requests: it reports the state of
+# the live org, which no individual PR controls, so it must not gate merges.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 5 * * *"
+
+permissions: {}
+
+jobs:
+  repository-drift-check:
+    name: 🔍 Repository drift check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+    steps:
+      - name: 🔑 Get GitHub App Token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Least-privilege scope (zizmor github-app): the check only reads
+          # repository settings, and the org has a private repository that the
+          # workflow's own GITHUB_TOKEN cannot see.
+          permission-metadata: read
+
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🔍 Compare declared and live repository settings
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: bash scripts/check-repository-drift.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,10 @@ bash tests/declarative-coverage.sh      # every repo declared in every rendered 
 bash tests/declarative-coverage-fail-closed.sh # rendered-label reads fail closed
 bash tests/repository-update-policy.sh  # active Repository update invariants
 bash tests/release-contract.sh          # deploy/ changes must trigger a release
+bash tests/repository-drift.sh          # declared-vs-live comparison logic
 ```
 
-Those six commands are the baseline checks that `ci.yaml` runs. Pull requests additionally pass
+Those seven commands are the baseline checks that `ci.yaml` runs. Pull requests additionally pass
 their changed paths and title through `scripts/validate-release-contract.sh`; merge groups skip that
 event-specific check.
 
@@ -112,6 +113,12 @@ Repo-specific watch-list for the daily engineer:
 - **Drift / coverage.** New repos in the org, or org/repo/team settings changed in the UI, mean
   `deploy/` is now behind reality. Bringing them under management (Observe-first) is `roadmap`/
   `enhancement` work — never a UI fix.
+- **Declared settings that never landed.** `repository-drift-check.yaml` runs
+  [`scripts/check-repository-drift.sh`](scripts/check-repository-drift.sh) daily and fails when a
+  `forProvider` field disagrees with the live repository. Cluster state cannot answer this alone: a
+  `Repository` only PATCHes when it has a pending diff, so an `Observe`-only resource — or one whose
+  writes GitHub rejects — reports `Synced=ReconcileSuccess` while its declaration is never applied.
+  A `DRIFT` line is a real defect in one of those two shapes; fix the resource, never the live repo.
 - **`cd.yaml` is the publish path**, triggered on `v*` tags only; `ci.yaml` produces the PR-time
   required check. A red `cd.yaml` means the org-config OCI artifact didn't republish — investigate
   before assuming the live org is in sync.

--- a/scripts/check-repository-drift.sh
+++ b/scripts/check-repository-drift.sh
@@ -53,11 +53,22 @@ if [[ -z "$render" ]]; then
 fi
 [[ -s "$render" ]] || abort "rendered manifest is empty"
 
-# One JSON object per declared Repository: the resource name plus the settings
-# block that deploy/ claims authority over.
+# One JSON object per declared Repository: the repository it points at, the
+# resource that declares it, and the settings block deploy/ claims authority
+# over.
+#
+# crossplane.io/external-name is what identifies the repository on GitHub, and
+# it is not always the resource name — an adoption after a rename carries the
+# new name there while the resource keeps its own. Reading live state by the
+# resource name would then compare against the wrong repository, or against
+# none at all.
 yq -N -o=json -I=0 '
   select(.kind == "Repository") |
-  {"repo": .metadata.name, "declared": .spec.forProvider}
+  {
+    "repo": (.metadata.annotations["crossplane.io/external-name"] // .metadata.name),
+    "resource": .metadata.name,
+    "declared": .spec.forProvider
+  }
 ' "$render" >"$work/declared.jsonl" || abort "failed to read Repository resources from the render"
 
 declared_count="$(grep -c . "$work/declared.jsonl" || true)"
@@ -79,6 +90,8 @@ drift_found=0
 while IFS= read -r entry; do
   [[ -n "$entry" ]] || continue
   repo="$(jq -r '.repo' <<<"$entry")"
+  # Only worth saying when the two differ; otherwise it is noise on every line.
+  where="$(jq -r 'if .resource == .repo then "" else " [declared by \(.resource)]" end' <<<"$entry")"
 
   if [[ -n "$live_dir" ]]; then
     live_file="$live_dir/$repo.json"
@@ -104,8 +117,8 @@ while IFS= read -r entry; do
           | if ($live | has($k)) | not then
               {field: .key, api: $k, status: "unmapped"}
             else
-              (if $k == "topics" then (.value | sort) else .value end) as $want
-              | (if $k == "topics" then ($live[$k] | sort) else $live[$k] end) as $got
+              (if $k == "topics" then (.value | unique) else .value end) as $want
+              | (if $k == "topics" then ($live[$k] | unique) else $live[$k] end) as $got
               | if $want == $got then empty
                 else {field: .key, api: $k, declared: $want, live: $got, status: "drift"}
                 end
@@ -118,13 +131,13 @@ while IFS= read -r entry; do
   while IFS= read -r finding; do
     [[ -n "$finding" ]] || continue
     if [[ "$(jq -r '.status' <<<"$finding")" == "unmapped" ]]; then
-      abort "$(jq -r --arg repo "$repo" '
-        "\($repo) declares \(.field) but the live repository object has no \(.api|tojson) field"
+      abort "$(jq -r --arg repo "$repo" --arg where "$where" '
+        "\($repo)\($where) declares \(.field) but the live repository object has no \(.api|tojson) field"
       ' <<<"$finding")"
     fi
     drift_found=1
-    jq -r --arg repo "$repo" '
-      "DRIFT \($repo).\(.field): declared=\(.declared | tojson) live=\(.live | tojson)"
+    jq -r --arg repo "$repo" --arg where "$where" '
+      "DRIFT \($repo).\(.field)\($where): declared=\(.declared | tojson) live=\(.live | tojson)"
     ' <<<"$finding"
   done <<<"$findings"
 done <"$work/declared.jsonl"

--- a/scripts/check-repository-drift.sh
+++ b/scripts/check-repository-drift.sh
@@ -92,6 +92,7 @@ while IFS= read -r entry; do
   repo="$(jq -r '.repo' <<<"$entry")"
   # Only worth saying when the two differ; otherwise it is noise on every line.
   where="$(jq -r 'if .resource == .repo then "" else " [declared by \(.resource)]" end' <<<"$entry")"
+  is_private=false
 
   if [[ -n "$live_dir" ]]; then
     live_file="$live_dir/$repo.json"
@@ -103,6 +104,14 @@ while IFS= read -r entry; do
   fi
   jq -e 'type == "object"' >/dev/null <<<"$live" ||
     abort "live state for '$repo' is not a JSON object"
+
+  # This repository is public, so its Actions logs are public. A private
+  # repository's description, homepage or topics must not be printed into them,
+  # so a finding on one names the field and withholds both values. Absent the
+  # flag the sensitivity cannot be judged, so it aborts rather than guessing.
+  jq -e 'has("private")' >/dev/null <<<"$live" ||
+    abort "live state for '$repo' has no 'private' flag, so its findings cannot be safely printed"
+  is_private="$(jq -r 'if .private == true then "true" else "false" end' <<<"$live")"
 
   # A declared field with no counterpart on the live object means the mapping
   # is wrong or the API changed shape. Silently skipping it would let a whole
@@ -136,8 +145,10 @@ while IFS= read -r entry; do
       ' <<<"$finding")"
     fi
     drift_found=1
-    jq -r --arg repo "$repo" --arg where "$where" '
-      "DRIFT \($repo).\(.field)\($where): declared=\(.declared | tojson) live=\(.live | tojson)"
+    jq -r --arg repo "$repo" --arg where "$where" --argjson private "$is_private" '
+      "DRIFT \($repo).\(.field)\($where): " +
+      (if $private then "values withheld — private repository"
+       else "declared=\(.declared | tojson) live=\(.live | tojson)" end)
     ' <<<"$finding"
   done <<<"$findings"
 done <"$work/declared.jsonl"

--- a/scripts/check-repository-drift.sh
+++ b/scripts/check-repository-drift.sh
@@ -118,7 +118,9 @@ while IFS= read -r entry; do
   while IFS= read -r finding; do
     [[ -n "$finding" ]] || continue
     if [[ "$(jq -r '.status' <<<"$finding")" == "unmapped" ]]; then
-      abort "$repo declares '$(jq -r '.field' <<<"$finding")' but the live repository object has no '$(jq -r '.api' <<<"$finding")' field"
+      abort "$(jq -r --arg repo "$repo" '
+        "\($repo) declares \(.field) but the live repository object has no \(.api|tojson) field"
+      ' <<<"$finding")"
     fi
     drift_found=1
     jq -r --arg repo "$repo" '

--- a/scripts/check-repository-drift.sh
+++ b/scripts/check-repository-drift.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Reports every declared repository setting in deploy/ that disagrees with the
+# live repository on GitHub.
+#
+# A Repository managed resource only issues an update PATCH when it has a
+# pending diff, so one whose writes are rejected still reports
+# Synced=ReconcileSuccess once the provider stops retrying. A declaration that
+# never landed is therefore indistinguishable from one that did, by reading
+# cluster state alone. This compares the two ends directly instead.
+#
+# Read-only. It never writes GitHub state, so it is safe to run against the
+# managed org (deploy/ stays the only way to change configuration).
+#
+# Environment:
+#   REPOSITORY_DRIFT_OWNER      org to read live state from (default devantler-tech)
+#   REPOSITORY_DRIFT_RENDER     pre-rendered deploy/ manifest; default renders deploy/
+#   REPOSITORY_DRIFT_LIVE_DIR   directory of <repo>.json live fixtures; default reads
+#                               the GitHub API. Used by tests to stay hermetic.
+#
+# Exit codes:
+#   0  every declared field matches live
+#   1  at least one declared field diverges from live
+#   2  the check could not be completed (fail closed)
+
+set -euo pipefail
+
+owner="${REPOSITORY_DRIFT_OWNER:-devantler-tech}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+render="${REPOSITORY_DRIFT_RENDER:-}"
+live_dir="${REPOSITORY_DRIFT_LIVE_DIR:-}"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+abort() {
+  echo "repository-drift: $*" >&2
+  exit 2
+}
+
+for tool in yq jq; do
+  command -v "$tool" >/dev/null || abort "required tool '$tool' not found"
+done
+
+if [[ -z "$live_dir" ]]; then
+  command -v gh >/dev/null || abort "required tool 'gh' not found"
+fi
+
+if [[ -z "$render" ]]; then
+  command -v kubectl >/dev/null || abort "required tool 'kubectl' not found"
+  render="$work/render.yaml"
+  kubectl kustomize "$repo_root/deploy" >"$render" ||
+    abort "kubectl kustomize deploy/ failed"
+fi
+[[ -s "$render" ]] || abort "rendered manifest is empty"
+
+# One JSON object per declared Repository: the resource name plus the settings
+# block that deploy/ claims authority over.
+yq -N -o=json -I=0 '
+  select(.kind == "Repository") |
+  {"repo": .metadata.name, "declared": .spec.forProvider}
+' "$render" >"$work/declared.jsonl" || abort "failed to read Repository resources from the render"
+
+declared_count="$(grep -c . "$work/declared.jsonl" || true)"
+# deploy/ manages the whole org; a render that yields almost nothing means the
+# read broke rather than that the org shrank, and reporting "no drift" from it
+# would be a fail-open.
+[[ "$declared_count" -ge 10 ]] ||
+  abort "declared Repository set collapsed to $declared_count entries"
+
+# forProvider is camelCase; the REST repository object is snake_case. Only
+# homepageUrl is not a pure case change.
+readonly KEY_PROGRAM='
+  def to_snake: gsub("(?<c>[A-Z])"; "_" + (.c | ascii_downcase));
+  def api_key: {"homepageUrl": "homepage"}[.] // to_snake;
+'
+
+drift_found=0
+
+while IFS= read -r entry; do
+  [[ -n "$entry" ]] || continue
+  repo="$(jq -r '.repo' <<<"$entry")"
+
+  if [[ -n "$live_dir" ]]; then
+    live_file="$live_dir/$repo.json"
+    [[ -f "$live_file" ]] || abort "no live fixture for '$repo' at $live_file"
+    live="$(cat "$live_file")"
+  else
+    live="$(gh api "repos/$owner/$repo")" ||
+      abort "failed to read live state for '$owner/$repo'"
+  fi
+  jq -e 'type == "object"' >/dev/null <<<"$live" ||
+    abort "live state for '$repo' is not a JSON object"
+
+  # A declared field with no counterpart on the live object means the mapping
+  # is wrong or the API changed shape. Silently skipping it would let a whole
+  # class of settings go unchecked while the run still reported success, so it
+  # aborts instead of passing.
+  findings="$(
+    jq -c --argjson live "$live" "$KEY_PROGRAM"'
+      .declared
+      | to_entries
+      | map(
+          (.key | api_key) as $k
+          | if ($live | has($k)) | not then
+              {field: .key, api: $k, status: "unmapped"}
+            else
+              (if $k == "topics" then (.value | sort) else .value end) as $want
+              | (if $k == "topics" then ($live[$k] | sort) else $live[$k] end) as $got
+              | if $want == $got then empty
+                else {field: .key, api: $k, declared: $want, live: $got, status: "drift"}
+                end
+            end
+        )
+      | .[]
+    ' <<<"$entry"
+  )" || abort "failed to compare declared and live state for '$repo'"
+
+  while IFS= read -r finding; do
+    [[ -n "$finding" ]] || continue
+    if [[ "$(jq -r '.status' <<<"$finding")" == "unmapped" ]]; then
+      abort "$repo declares '$(jq -r '.field' <<<"$finding")' but the live repository object has no '$(jq -r '.api' <<<"$finding")' field"
+    fi
+    drift_found=1
+    jq -r --arg repo "$repo" '
+      "DRIFT \($repo).\(.field): declared=\(.declared | tojson) live=\(.live | tojson)"
+    ' <<<"$finding"
+  done <<<"$findings"
+done <"$work/declared.jsonl"
+
+if [[ "$drift_found" -ne 0 ]]; then
+  echo "repository-drift: declared and live GitHub state disagree (see DRIFT lines above)" >&2
+  exit 1
+fi
+
+echo "repository-drift: OK — $declared_count declared repositories match live GitHub state"

--- a/tests/repository-drift.sh
+++ b/tests/repository-drift.sh
@@ -101,8 +101,10 @@ mv "$work/drift/live/fixture-repo-3.json.new" "$work/drift/live/fixture-repo-3.j
 expect_status "$work/drift" 1 "a diverging field"
 grep -Fq "DRIFT fixture-repo-3.visibility:" "$work/drift/stdout" ||
   fail "the drifting repository and field must be named on stdout"
-grep -Fq "DRIFT fixture-repo-1." "$work/drift/stdout" &&
-  fail "an agreeing repository must not be reported as drifting"
+# Exactly one, so a check that flagged everything could not pass this either.
+drift_lines="$(grep -c '^DRIFT ' "$work/drift/stdout" || true)"
+[[ "$drift_lines" -eq 1 ]] ||
+  fail "expected exactly one DRIFT line, got $drift_lines"
 
 # --- 3. drift on a multi-word field, i.e. through the case mapping -----------
 # A mapping bug would compare against a key the live object does not have, which
@@ -132,8 +134,9 @@ expect_status "$work/topics-drift" 1 "a missing topic"
 build_fixture "$work/unmapped"
 sed -i.bak 's/^    hasIssues: true$/    hasIssues: true\n    inventedSetting: true/' "$work/unmapped/render.yaml"
 expect_status "$work/unmapped" 2 "a declared field absent from the live object"
-grep -Fq "has no 'invented_setting' field" "$work/unmapped/stderr" ||
-  fail "the unmappable field must be named"
+grep -Fq 'inventedSetting but the live repository object has no "invented_setting" field' \
+  "$work/unmapped/stderr" ||
+  fail "the unmappable field must be named under both its declared and its mapped name"
 
 # --- 6. fail closed: live state unavailable ----------------------------------
 build_fixture "$work/missing"

--- a/tests/repository-drift.sh
+++ b/tests/repository-drift.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Exercises scripts/check-repository-drift.sh against hand-written fixtures, so
+# the comparison and the camelCase-to-snake_case field mapping are tested
+# without touching the network.
+#
+# The cases that matter are the ones where a wrong answer is silent: a drift the
+# check misses, and a field it cannot map reported as agreement.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+check="$repo_root/scripts/check-repository-drift.sh"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  echo "repository-drift test: $*" >&2
+  exit 1
+}
+
+# The check refuses to run on a render that yields fewer than ten repositories,
+# so every fixture set has to clear that floor.
+readonly FIXTURE_REPOS=10
+
+# Builds a render + live pair that agree on every declared field. Callers mutate
+# one of the two afterwards to create the case under test.
+build_fixture() {
+  local dir="$1" i name
+  mkdir -p "$dir/live"
+  : >"$dir/render.yaml"
+  for ((i = 1; i <= FIXTURE_REPOS; i++)); do
+    name="fixture-repo-$i"
+    cat >>"$dir/render.yaml" <<EOF
+---
+apiVersion: repo.github.m.upbound.io/v1alpha1
+kind: Repository
+metadata:
+  name: $name
+spec:
+  managementPolicies: [Observe, Create, Update]
+  forProvider:
+    name: $name
+    description: "fixture $i"
+    homepageUrl: "https://example.invalid/$i"
+    visibility: public
+    hasIssues: true
+    allowSquashMerge: true
+    allowMergeCommit: false
+    webCommitSignoffRequired: true
+    topics: ["beta", "alpha"]
+EOF
+    # Written in the REST object's own snake_case, by hand, so the mapping the
+    # check derives has something independent to be wrong against. topics is
+    # deliberately in the other order: the check compares it as a set.
+    cat >"$dir/live/$name.json" <<EOF
+{
+  "name": "$name",
+  "description": "fixture $i",
+  "homepage": "https://example.invalid/$i",
+  "visibility": "public",
+  "has_issues": true,
+  "allow_squash_merge": true,
+  "allow_merge_commit": false,
+  "web_commit_signoff_required": true,
+  "topics": ["alpha", "beta"]
+}
+EOF
+  done
+}
+
+run_check() {
+  local dir="$1"
+  REPOSITORY_DRIFT_RENDER="$dir/render.yaml" \
+    REPOSITORY_DRIFT_LIVE_DIR="$dir/live" \
+    bash "$check" >"$dir/stdout" 2>"$dir/stderr"
+}
+
+expect_status() {
+  local dir="$1" want="$2" what="$3" got=0
+  run_check "$dir" || got=$?
+  [[ "$got" -eq "$want" ]] || {
+    echo "repository-drift test: $what expected exit $want, got $got" >&2
+    cat "$dir/stdout" "$dir/stderr" >&2
+    exit 1
+  }
+}
+
+# --- 1. agreement: every declared field matches live -------------------------
+build_fixture "$work/clean"
+expect_status "$work/clean" 0 "matching fixtures"
+grep -Fq "repository-drift: OK" "$work/clean/stdout" ||
+  fail "a clean run must say so on stdout"
+
+# --- 2. drift: one declared field disagrees ----------------------------------
+# visibility is the field devantler-tech/.github#123 was opened about: declared
+# private, live public, and nothing surfaced it.
+build_fixture "$work/drift"
+jq '.visibility = "private"' "$work/drift/live/fixture-repo-3.json" >"$work/drift/live/fixture-repo-3.json.new"
+mv "$work/drift/live/fixture-repo-3.json.new" "$work/drift/live/fixture-repo-3.json"
+expect_status "$work/drift" 1 "a diverging field"
+grep -Fq "DRIFT fixture-repo-3.visibility:" "$work/drift/stdout" ||
+  fail "the drifting repository and field must be named on stdout"
+grep -Fq "DRIFT fixture-repo-1." "$work/drift/stdout" &&
+  fail "an agreeing repository must not be reported as drifting"
+
+# --- 3. drift on a multi-word field, i.e. through the case mapping -----------
+# A mapping bug would compare against a key the live object does not have, which
+# case 4 pins as an abort; this pins that a correctly mapped field still
+# compares by VALUE rather than being skipped.
+build_fixture "$work/drift-snake"
+jq '.web_commit_signoff_required = false' "$work/drift-snake/live/fixture-repo-5.json" >"$work/drift-snake/live/fixture-repo-5.json.new"
+mv "$work/drift-snake/live/fixture-repo-5.json.new" "$work/drift-snake/live/fixture-repo-5.json"
+expect_status "$work/drift-snake" 1 "a diverging multi-word field"
+grep -Fq "DRIFT fixture-repo-5.webCommitSignoffRequired:" "$work/drift-snake/stdout" ||
+  fail "a multi-word field must be reported under its declared name"
+
+# --- 4. topics compare as a set, not as an ordered list ----------------------
+build_fixture "$work/topics"
+jq '.topics = ["beta", "alpha"]' "$work/topics/live/fixture-repo-2.json" >"$work/topics/live/fixture-repo-2.json.new"
+mv "$work/topics/live/fixture-repo-2.json.new" "$work/topics/live/fixture-repo-2.json"
+expect_status "$work/topics" 0 "topics in a different order"
+
+build_fixture "$work/topics-drift"
+jq '.topics = ["alpha"]' "$work/topics-drift/live/fixture-repo-2.json" >"$work/topics-drift/live/fixture-repo-2.json.new"
+mv "$work/topics-drift/live/fixture-repo-2.json.new" "$work/topics-drift/live/fixture-repo-2.json"
+expect_status "$work/topics-drift" 1 "a missing topic"
+
+# --- 5. fail closed: a declared field with no live counterpart ---------------
+# Skipping it would leave that setting permanently unchecked while the run still
+# reported success.
+build_fixture "$work/unmapped"
+sed -i.bak 's/^    hasIssues: true$/    hasIssues: true\n    inventedSetting: true/' "$work/unmapped/render.yaml"
+expect_status "$work/unmapped" 2 "a declared field absent from the live object"
+grep -Fq "has no 'invented_setting' field" "$work/unmapped/stderr" ||
+  fail "the unmappable field must be named"
+
+# --- 6. fail closed: live state unavailable ----------------------------------
+build_fixture "$work/missing"
+rm "$work/missing/live/fixture-repo-4.json"
+expect_status "$work/missing" 2 "unreadable live state"
+
+# --- 7. fail closed: the render collapsed ------------------------------------
+# An empty or truncated render must never read as "nothing drifted".
+build_fixture "$work/collapsed"
+yq -N -i 'select(.metadata.name == "fixture-repo-1")' "$work/collapsed/render.yaml"
+expect_status "$work/collapsed" 2 "a collapsed render"
+grep -Fq "collapsed to" "$work/collapsed/stderr" ||
+  fail "a collapsed render must say so"
+
+echo "repository-drift: OK — agreement, drift, set-compare and three fail-closed paths"

--- a/tests/repository-drift.sh
+++ b/tests/repository-drift.sh
@@ -33,11 +33,11 @@ readonly RENAMED_EXTERNAL="fixture-repo-7-renamed"
 # one side afterwards to create the case under test.
 #
 # $2, when given, names the one repository whose DECLARED topics repeat an
-# entry. Built in rather than patched in afterwards: an in-place yq edit of a
-# multi-document render merges it into a single document and loses every
-# repository but the last.
+# entry; $3 the one whose live state is private. Built in rather than patched in
+# afterwards: an in-place yq edit of a multi-document render merges it into a
+# single document and loses every repository but the last.
 build_fixture() {
-  local dir="$1" dup_topics_repo="${2:-}" i name external topics
+  local dir="$1" dup_topics_repo="${2:-}" private_repo="${3:-}" i name external topics is_private
   mkdir -p "$dir/live"
   : >"$dir/render.yaml"
   for ((i = 1; i <= FIXTURE_REPOS; i++)); do
@@ -45,6 +45,8 @@ build_fixture() {
     external="$name"
     [[ "$name" == "$RENAMED_RESOURCE" ]] && external="$RENAMED_EXTERNAL"
     topics='["beta", "alpha"]'
+    is_private=false
+    [[ -n "$private_repo" && "$name" == "$private_repo" ]] && is_private=true
     [[ -n "$dup_topics_repo" && "$name" == "$dup_topics_repo" ]] && topics='["beta", "alpha", "beta"]'
     cat >>"$dir/render.yaml" <<EOF
 ---
@@ -79,6 +81,7 @@ EOF
   "has_issues": true,
   "allow_squash_merge": true,
   "allow_merge_commit": false,
+  "private": $is_private,
   "web_commit_signoff_required": true,
   "topics": ["alpha", "beta"]
 }
@@ -170,7 +173,39 @@ grep -Fq "DRIFT $RENAMED_EXTERNAL.visibility [declared by $RENAMED_RESOURCE]" \
   "$work/renamed-drift/stdout" ||
   fail "drift on a renamed repository must name the repository and the declaring resource"
 
-# --- 7. fail closed: a declared field with no live counterpart ---------------
+# --- 7. a private repository's values are withheld from the output -----------
+# This repository is public, so its Actions logs are public. A finding on a
+# private repository must name the field and print neither value.
+build_fixture "$work/private" "" "fixture-repo-4"
+jq '.description = "an internal description that must not be printed"' \
+  "$work/private/live/fixture-repo-4.json" >"$work/private/live/tmp.json"
+mv "$work/private/live/tmp.json" "$work/private/live/fixture-repo-4.json"
+expect_status "$work/private" 1 "drift on a private repository"
+grep -Fq "DRIFT fixture-repo-4.description: values withheld — private repository" \
+  "$work/private/stdout" ||
+  fail "a private repository's finding must name the field and withhold the values"
+if grep -Fq "an internal description that must not be printed" "$work/private/stdout" "$work/private/stderr"; then
+  fail "a private repository's live value leaked into the output"
+fi
+
+# A public repository is unaffected — the values are what make a finding useful.
+build_fixture "$work/public-values"
+jq '.description = "a public description that should be printed"' \
+  "$work/public-values/live/fixture-repo-4.json" >"$work/public-values/live/tmp.json"
+mv "$work/public-values/live/tmp.json" "$work/public-values/live/fixture-repo-4.json"
+expect_status "$work/public-values" 1 "drift on a public repository"
+grep -Fq "a public description that should be printed" "$work/public-values/stdout" ||
+  fail "a public repository's values must still be reported"
+
+# --- 8. fail closed: live state whose visibility cannot be determined --------
+build_fixture "$work/no-private-flag"
+jq 'del(.private)' "$work/no-private-flag/live/fixture-repo-2.json" >"$work/no-private-flag/live/tmp.json"
+mv "$work/no-private-flag/live/tmp.json" "$work/no-private-flag/live/fixture-repo-2.json"
+expect_status "$work/no-private-flag" 2 "live state with no private flag"
+grep -Fq "has no 'private' flag" "$work/no-private-flag/stderr" ||
+  fail "the missing visibility flag must be named"
+
+# --- 9. fail closed: a declared field with no live counterpart ---------------
 # Skipping it would leave that setting permanently unchecked while the run still
 # reported success.
 build_fixture "$work/unmapped"
@@ -180,12 +215,12 @@ grep -Fq 'inventedSetting but the live repository object has no "invented_settin
   "$work/unmapped/stderr" ||
   fail "the unmappable field must be named under both its declared and its mapped name"
 
-# --- 8. fail closed: live state unavailable ----------------------------------
+# --- 10. fail closed: live state unavailable ----------------------------------
 build_fixture "$work/missing"
 rm "$work/missing/live/fixture-repo-4.json"
 expect_status "$work/missing" 2 "unreadable live state"
 
-# --- 9. fail closed: the render collapsed ------------------------------------
+# --- 11. fail closed: the render collapsed ------------------------------------
 # An empty or truncated render must never read as "nothing drifted".
 build_fixture "$work/collapsed"
 yq -N -i 'select(.metadata.name == "fixture-repo-1")' "$work/collapsed/render.yaml"
@@ -193,4 +228,4 @@ expect_status "$work/collapsed" 2 "a collapsed render"
 grep -Fq "collapsed to" "$work/collapsed/stderr" ||
   fail "a collapsed render must say so"
 
-echo "repository-drift: OK — agreement, drift, set-compare, external-name and three fail-closed paths"
+echo "repository-drift: OK — agreement, drift, set-compare, external-name, private redaction and four fail-closed paths"

--- a/tests/repository-drift.sh
+++ b/tests/repository-drift.sh
@@ -23,24 +23,41 @@ fail() {
 # so every fixture set has to clear that floor.
 readonly FIXTURE_REPOS=10
 
-# Builds a render + live pair that agree on every declared field. Callers mutate
-# one of the two afterwards to create the case under test.
+# The one repository whose resource name and external name deliberately differ,
+# as an adoption after a rename does. Its live fixture is named after the
+# EXTERNAL name, so reading live state by the resource name finds nothing.
+readonly RENAMED_RESOURCE="fixture-repo-7"
+readonly RENAMED_EXTERNAL="fixture-repo-7-renamed"
+
+# Builds a render + live pair that agree on every declared field; callers mutate
+# one side afterwards to create the case under test.
+#
+# $2, when given, names the one repository whose DECLARED topics repeat an
+# entry. Built in rather than patched in afterwards: an in-place yq edit of a
+# multi-document render merges it into a single document and loses every
+# repository but the last.
 build_fixture() {
-  local dir="$1" i name
+  local dir="$1" dup_topics_repo="${2:-}" i name external topics
   mkdir -p "$dir/live"
   : >"$dir/render.yaml"
   for ((i = 1; i <= FIXTURE_REPOS; i++)); do
     name="fixture-repo-$i"
+    external="$name"
+    [[ "$name" == "$RENAMED_RESOURCE" ]] && external="$RENAMED_EXTERNAL"
+    topics='["beta", "alpha"]'
+    [[ -n "$dup_topics_repo" && "$name" == "$dup_topics_repo" ]] && topics='["beta", "alpha", "beta"]'
     cat >>"$dir/render.yaml" <<EOF
 ---
 apiVersion: repo.github.m.upbound.io/v1alpha1
 kind: Repository
 metadata:
   name: $name
+  annotations:
+    crossplane.io/external-name: $external
 spec:
   managementPolicies: [Observe, Create, Update]
   forProvider:
-    name: $name
+    name: $external
     description: "fixture $i"
     homepageUrl: "https://example.invalid/$i"
     visibility: public
@@ -48,14 +65,14 @@ spec:
     allowSquashMerge: true
     allowMergeCommit: false
     webCommitSignoffRequired: true
-    topics: ["beta", "alpha"]
+    topics: $topics
 EOF
     # Written in the REST object's own snake_case, by hand, so the mapping the
     # check derives has something independent to be wrong against. topics is
     # deliberately in the other order: the check compares it as a set.
-    cat >"$dir/live/$name.json" <<EOF
+    cat >"$dir/live/$external.json" <<EOF
 {
-  "name": "$name",
+  "name": "$external",
   "description": "fixture $i",
   "homepage": "https://example.invalid/$i",
   "visibility": "public",
@@ -128,7 +145,32 @@ jq '.topics = ["alpha"]' "$work/topics-drift/live/fixture-repo-2.json" >"$work/t
 mv "$work/topics-drift/live/fixture-repo-2.json.new" "$work/topics-drift/live/fixture-repo-2.json"
 expect_status "$work/topics-drift" 1 "a missing topic"
 
-# --- 5. fail closed: a declared field with no live counterpart ---------------
+# --- 5. duplicate topics are a set, not a multiset ---------------------------
+# A declaration that repeats a topic is untidy, but it is not a disagreement
+# with live: GitHub cannot hold the duplicate, so reporting drift would name a
+# divergence no change to the repository could ever close.
+build_fixture "$work/topics-dupe" "fixture-repo-6"
+expect_status "$work/topics-dupe" 0 "a duplicated declared topic"
+
+# --- 6. live state is read by external name, not resource name ---------------
+# The renamed fixture's live state is filed under its external name only, so a
+# check keying on metadata.name cannot find it.
+build_fixture "$work/renamed"
+expect_status "$work/renamed" 0 "a resource whose external name differs"
+[[ -f "$work/renamed/live/$RENAMED_EXTERNAL.json" && ! -f "$work/renamed/live/$RENAMED_RESOURCE.json" ]] ||
+  fail "the renamed fixture must exist only under its external name"
+
+# Drift on that repository is reported against the external name, and says which
+# resource declared it.
+build_fixture "$work/renamed-drift"
+jq '.visibility = "private"' "$work/renamed-drift/live/$RENAMED_EXTERNAL.json" >"$work/renamed-drift/live/tmp.json"
+mv "$work/renamed-drift/live/tmp.json" "$work/renamed-drift/live/$RENAMED_EXTERNAL.json"
+expect_status "$work/renamed-drift" 1 "drift on a renamed repository"
+grep -Fq "DRIFT $RENAMED_EXTERNAL.visibility [declared by $RENAMED_RESOURCE]" \
+  "$work/renamed-drift/stdout" ||
+  fail "drift on a renamed repository must name the repository and the declaring resource"
+
+# --- 7. fail closed: a declared field with no live counterpart ---------------
 # Skipping it would leave that setting permanently unchecked while the run still
 # reported success.
 build_fixture "$work/unmapped"
@@ -138,12 +180,12 @@ grep -Fq 'inventedSetting but the live repository object has no "invented_settin
   "$work/unmapped/stderr" ||
   fail "the unmappable field must be named under both its declared and its mapped name"
 
-# --- 6. fail closed: live state unavailable ----------------------------------
+# --- 8. fail closed: live state unavailable ----------------------------------
 build_fixture "$work/missing"
 rm "$work/missing/live/fixture-repo-4.json"
 expect_status "$work/missing" 2 "unreadable live state"
 
-# --- 7. fail closed: the render collapsed ------------------------------------
+# --- 9. fail closed: the render collapsed ------------------------------------
 # An empty or truncated render must never read as "nothing drifted".
 build_fixture "$work/collapsed"
 yq -N -i 'select(.metadata.name == "fixture-repo-1")' "$work/collapsed/render.yaml"
@@ -151,4 +193,4 @@ expect_status "$work/collapsed" 2 "a collapsed render"
 grep -Fq "collapsed to" "$work/collapsed/stderr" ||
   fail "a collapsed render must say so"
 
-echo "repository-drift: OK — agreement, drift, set-compare and three fail-closed paths"
+echo "repository-drift: OK — agreement, drift, set-compare, external-name and three fail-closed paths"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The org's GitHub settings are declared in `deploy/`, but nothing has been checking that what we
declare is what GitHub actually has. It turns out two different things can silently swallow a
declaration, and both look healthy from the cluster:

- a repository we only *watch* rather than *manage* still gets our shared merge policy stamped onto
  its declaration — so the config claims authority it never had;
- a repository whose updates GitHub rejects keeps reporting success once it stops retrying.

Running this check for the first time found a real one nobody knew about: **World at Ruin still
allows merge commits and rebase merges**, though the config says squash-only like every other repo.
That is the merge policy the release pipeline depends on. It also confirms the two repositories
whose topics have never been applied (already tracked in #137).

## What

A daily read-only check that compares every declared repository setting against the live repository
and fails when they disagree, naming the repository and the field. It never writes to GitHub —
`deploy/` stays the only way to change configuration.

It refuses to report "all clear" when it could not actually establish that: a truncated read, an
unreachable repository, or a setting it cannot line up against the live object each stop the run
instead of passing.

**Expect it to be red until the three known divergences are fixed.** That is the check working, not
a defect in it — each has its own issue.

Part of #123
