### PR TITLE
fix(ci): give the repository drift check administrative read

### DIFF
--- a/.github/workflows/repository-drift-check.yaml
+++ b/.github/workflows/repository-drift-check.yaml
@@ -59,12 +59,21 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          # Least-privilege scope (zizmor github-app): metadata only, and only
-          # over the declared repositories. The workflow's own GITHUB_TOKEN
-          # cannot be used instead — it reaches this repository alone, and the
-          # org has a private repository it could not see either way.
+          # Least-privilege scope (zizmor github-app): read-only, and only over
+          # the declared repositories. The workflow's own GITHUB_TOKEN cannot be
+          # used instead — it reaches this repository alone, and the org has a
+          # private repository it could not see either way.
+          #
+          # `administration: read` is what the merge-policy and feature fields
+          # need: GitHub returns allow_squash_merge, allow_merge_commit,
+          # allow_rebase_merge, allow_auto_merge, allow_update_branch,
+          # delete_branch_on_merge and web_commit_signoff_required only to a
+          # caller with administrative read. Under metadata alone the repository
+          # object simply omits them, and the check aborts — which is how this
+          # was found, on the first live run.
           owner: ${{ github.repository_owner }}
           repositories: ${{ steps.targets.outputs.list }}
+          permission-administration: read
           permission-metadata: read
 
       - name: 🔍 Compare declared and live repository settings


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The repository drift check merged an hour ago and its first live run could not do its job. It stopped
on the first repository, because GitHub had returned a repository object with the merge and feature
settings missing entirely — the exact fields the check exists to compare.

It looked correct locally because a maintainer's own credentials carry administrative access and
GitHub returns those fields to them; the workflow's credentials did not.

The check stopping was the right behaviour — it refused to report "no drift" from an object it could
tell was incomplete — but it needs the right access to be useful at all.

## What

Gives the check administrative **read** access to the repositories it already reads. Still read-only,
still limited to the repositories declared in `deploy/`, and it still cannot change anything.

Hotfix for the scheduled run, which is red on `main` right now.
