### PR TITLE
fix(ci): stop scheduling the drift check until the App can read settings

### DIFF
--- a/.github/workflows/repository-drift-check.yaml
+++ b/.github/workflows/repository-drift-check.yaml
@@ -9,13 +9,17 @@ name: 🔍 Repository drift check
 # reports Synced=ReconcileSuccess indefinitely while its declaration goes
 # unapplied. Comparing the two ends directly is what catches that.
 #
-# This runs on a schedule rather than on pull requests: it reports the state of
-# the live org, which no individual PR controls, so it must not gate merges.
+# It reports the state of the live org, which no individual PR controls, so it
+# belongs on a schedule and must never gate a merge.
 
 on:
+  # Dispatch only, until the App is granted Administration: Read-only
+  # (devantler-tech/.github#144). Without it the token request itself is refused
+  # with 422, so a scheduled run would fail every day on something no change in
+  # this repository can fix. Restore the schedule when the permission lands:
+  #   schedule:
+  #     - cron: "17 5 * * *"
   workflow_dispatch:
-  schedule:
-    - cron: "17 5 * * *"
 
 permissions: {}
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The repository drift check I merged an hour ago cannot run at all. It needs to read each repository's
merge and feature settings, and GitHub hands those out only to a caller with administrative read —
which the App behind our workflows does not currently have. The request for it is refused outright,
so the daily run would fail every morning on something no change in this repository can fix.

Granting that access is an organisation-owner action, so it is tracked separately in #144.

## What

Takes the check off the daily schedule until then. It can still be run on demand, and turning the
schedule back on is a one-line change.

It deliberately does **not** shrink the check to the handful of settings the current access can see.
Quietly checking fewer things than the config claims to control is the exact problem this check was
built to catch, and it would have hidden the one real divergence it has already found (#141).

Part of #144
