### PR TITLE
docs(cd): state that the workflow ref is load-bearing for cosign verification

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,8 +35,11 @@ jobs:
     # Pinned to the released commit SHA (zizmor blanket policy requires a hash;
     # the SHA must be reachable from a tag, or zizmor flags it as an impostor).
     # Renovate manages this pin, as it does for publish-app.yaml elsewhere.
-    # The platform verifier matches `@.+$`, so the ref does not affect cosign
-    # verification.
+    # Keep the ref a 40-hex commit: it is part of the cosign subject the platform
+    # verifies, so its shape is load-bearing here. A ref the verifier does not
+    # accept fails nothing in this repo — the artifact still publishes, signed
+    # under an identity the platform rejects, and the `github-config` tenant
+    # stops reconciling until the ref is put back.
     uses: devantler-tech/actions/.github/workflows/publish-manifests.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
     with:
       oci-name: devantler-tech/github-config


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The comment above the publish-workflow pin told the next person to edit this file
that the ref shape is free — "the platform verifier matches `@.+$`, so the ref does
not affect cosign verification". That stopped being true when the platform narrowed
its cosign subject matcher, and it sits directly above the one line where the ref is
now load-bearing.

Acting on it fails nothing here. The artifact still publishes, signed under an
identity the platform rejects, and the consuming tenant quietly stops reconciling
some time later. Renovate keeps the pin's *value* correct, so nothing would force
the mistake to surface.

## What

The comment now states the real constraint — keep it a 40-hex commit — and what
breaks if it changes. It deliberately does not quote the current matcher regex,
since that is what went stale here twice.

Comment-only; the pinned SHA and everything else are untouched.

Part of devantler-tech/platform#3044
