### PR TITLE
security(ci): enforce a SHA-pinned publish caller and automate pin upkeep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      # devantler-tech actions/workflows are our own code — bump now, no cooldown.
+      exclude:
+        - "devantler-tech/*"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -34,12 +34,17 @@ jobs:
       id-token: write # keyless cosign signing (Fulcio + Rekor via GitHub OIDC)
     # Pinned to the released commit SHA (zizmor blanket policy requires a hash;
     # the SHA must be reachable from a tag, or zizmor flags it as an impostor).
-    # Renovate manages this pin, as it does for publish-app.yaml elsewhere.
+    # Dependabot manages this pin (.github/dependabot.yml, github-actions
+    # ecosystem, no cooldown for devantler-tech/*).
     # Keep the ref a 40-hex commit: it is part of the cosign subject the platform
-    # verifies, so its shape is load-bearing here. A ref the verifier does not
-    # accept fails nothing in this repo — the artifact still publishes, signed
-    # under an identity the platform rejects, and the `github-config` tenant
-    # stops reconciling until the ref is put back.
-    uses: devantler-tech/actions/.github/workflows/publish-manifests.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
+    # verifies, so its shape is load-bearing here.
+    uses: devantler-tech/actions/.github/workflows/publish-manifests.yaml@61d9c87b302523778789c7cf09655b87b6716e87 # v13.0.4
     with:
       oci-name: devantler-tech/github-config
+      # Without this, a ref the platform verifier does not accept fails nothing
+      # here: the artifact still publishes, signed under an identity the
+      # platform rejects, and the `github-config` tenant silently stops
+      # reconciling until the ref is put back. Enabling the guard turns that
+      # into a loud pre-signing failure in this workflow instead — the publish
+      # refuses before the artifact exists, and the error names the fix.
+      enable-caller-pin: true


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The workflow that publishes this org's declarative GitHub state was pinned five major versions
behind, and nothing was ever going to move it — this repo had no dependency automation at all. The
file even told readers "Renovate manages this pin", which was not true here.

Being stuck that far back also meant this repo could not adopt the guard that stops an old,
superseded publish pipeline from producing a signature the cluster still trusts.

## What

The publish now refuses to sign unless it was invoked from an exact, immovable revision, and
dependency automation keeps this repo current from here on. The misleading comment is corrected.

This matters more here than elsewhere because of a failure mode the file already documented: a ref
the cluster rejects **fails nothing in this repo** — the artifact publishes anyway, signed under an
identity the platform refuses, and the `github-config` tenant quietly stops reconciling until
someone notices. The guard turns that silent stall into a loud, immediate failure with the fix in
the error message.

**Security floor gained:** a superseded publish revision can no longer mint a signature for this
artifact. **Everyday cost:** none — releases are still a tag push, and pin upkeep moves from
"nobody" to automatic.

**Verification note:** the publish only runs on a release tag, so the final proof is the next tag
publish. The issue stays open for that; this merge does not close it.

Part of #149
Part of devantler-tech/platform#2818