### PR TITLE
fix(repositories): keep platform tenant issues enabled

### DIFF
--- a/deploy/repositories/platform-tenant-template.yaml
+++ b/deploy/repositories/platform-tenant-template.yaml
@@ -23,6 +23,7 @@ spec:
     # every other repository here can. Declaring the live value is what makes
     # restoring the write path (#112) unable to change it.
     visibility: public
+    hasIssues: true
     description: "Template for platform tenants on the devantler-tech platform — framework-agnostic CI/CD plumbing kept current via template-sync."
   providerConfigRef:
     kind: ProviderConfig

--- a/tests/repository-update-policy.sh
+++ b/tests/repository-update-policy.sh
@@ -115,7 +115,9 @@ platform_tenant_issues="$(
       .kind == "Repository" and
       .metadata.name == "platform-tenant-template"
     ) |
-    .spec.forProvider.hasIssues
+    .spec.forProvider.hasIssues |
+    select(tag == "!!bool") |
+    select(. == true)
   ' "$render"
 )"
 [[ "$platform_tenant_issues" == "true" ]] ||

--- a/tests/repository-update-policy.sh
+++ b/tests/repository-update-policy.sh
@@ -104,4 +104,21 @@ seeded_signoff="$(
 [[ -z "$seeded_signoff" ]] ||
   fail "signoff must be declared in forProvider, not the create-only initProvider: $seeded_signoff"
 
-echo "repository-update-policy: OK — $active_count active repositories declare org-enforced signoff"
+# This template's roadmap lives in its own GitHub Issues, so the active
+# Repository resource must keep that tracker enabled. As with signoff above, an
+# absent optional bool is not "unmanaged": provider zero-value behaviour makes
+# false authoritative on every update. Requiring the exact true value rejects
+# both removing the declaration and explicitly disabling it.
+platform_tenant_issues="$(
+  yq -N '
+    select(
+      .kind == "Repository" and
+      .metadata.name == "platform-tenant-template"
+    ) |
+    .spec.forProvider.hasIssues
+  ' "$render"
+)"
+[[ "$platform_tenant_issues" == "true" ]] ||
+  fail "platform-tenant-template must declare forProvider.hasIssues: true so its issue roadmap remains available"
+
+echo "repository-update-policy: OK — $active_count active repositories declare org-enforced signoff and the platform-tenant-template issue tracker"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Summary

- declare `hasIssues: true` in the authoritative `platform-tenant-template` Repository resource
- extend the repository update-policy gate so an absent or false setting fails closed
- restore the declarative path required to recover the existing roadmap Epic after reconciliation

## Validation

- `kubectl kustomize deploy`
- `bash tests/admin-team-policy.sh`
- `bash tests/declarative-coverage.sh`
- `bash tests/declarative-coverage-fail-closed.sh`
- `bash tests/repository-update-policy.sh`
- `bash tests/release-contract.sh`
- `bash tests/repository-drift.sh`

## Test-first evidence

The focused policy test failed before the manifest change because `hasIssues` was absent. It passed after the declaration was added. Explicit mutations to `false` and to an absent field both reproduced the intended policy failure before the final green run.

Fixes #148